### PR TITLE
Bug 526365 - Source pane font doesn't follow "Text font" setting

### DIFF
--- a/org.eclipse.wb.core.ui/plugin.xml
+++ b/org.eclipse.wb.core.ui/plugin.xml
@@ -9,6 +9,7 @@
 		<editor class="org.eclipse.wb.internal.core.editor.multi.DesignerEditor"
 			contributorClass="org.eclipse.wb.internal.core.editor.multi.DesignerEditorContributor"
 			extensions="java" icon="icons/gui_editor.gif" id="org.eclipse.wb.core.guiEditor"
+			symbolicFontName="org.eclipse.jdt.ui.editors.textfont"
 			name="WindowBuilder Editor">
 			<contentTypeBinding contentTypeId="org.eclipse.wb.core.javaSourceGUI"/>
 		</editor>


### PR DESCRIPTION
The source page now uses "Java Font" defined in the preferences of Eclipse (instead of using Basic > Text Font)