### PR TITLE
Bug 572210 - In eclipse.ini, add the VM argument --illegal-access=permit

### DIFF
--- a/org.eclipse.wb.core.feature_feature/build.properties
+++ b/org.eclipse.wb.core.feature_feature/build.properties
@@ -2,4 +2,5 @@ bin.includes = feature.xml,\
                feature.properties,\
                license.html,\
                epl-v10.html,\
-               eclipse_update_120.jpg
+               eclipse_update_120.jpg,\
+               p2.inf

--- a/org.eclipse.wb.core.feature_feature/p2.inf
+++ b/org.eclipse.wb.core.feature_feature/p2.inf
@@ -1,0 +1,4 @@
+# Workaround for bug 572210 (<https://bugs.eclipse.org/bugs/show_bug.cgi?id=572210>):
+# in "eclipse.ini" add the VM argument "--illegal-access=permit"
+instructions.configure=org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:--illegal-access=permit)
+instructions.unconfigure=org.eclipse.equinox.p2.touchpoint.eclipse.removeJvmArg(jvmArg:--illegal-access=permit)


### PR DESCRIPTION
Add the VM argument "--illegal-access=permit" to "eclipse.ini" via the
separate fragment "org.eclipse.wb.illegal_access_permit" and the p2
Eclipse touchpoint action "addJvmArg"
(<https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.isv/guide/p2_actions_touchpoints.html>)
as workaround for bug 572210
(<https://bugs.eclipse.org/bugs/show_bug.cgi?id=572210>).