### PR TITLE
Very subtle change to KeyStroke generation

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/accelerator/KeyStrokePropertyEditor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/accelerator/KeyStrokePropertyEditor.java
@@ -368,19 +368,19 @@ public final class KeyStrokePropertyEditor extends TextDialogPropertyEditor {
     {
       int modifiers = keyStroke.getModifiers();
       if ((modifiers & CTRL_MASK) != 0) {
-        modifiersSource += "java.awt.event.InputEvent.CTRL_MASK | ";
+        modifiersSource += "java.awt.event.InputEvent.CTRL_DOWN_MASK | ";
       }
       if ((modifiers & ALT_MASK) != 0) {
-        modifiersSource += "java.awt.event.InputEvent.ALT_MASK | ";
+        modifiersSource += "java.awt.event.InputEvent.ALT_DOWN_MASK | ";
       }
       if ((modifiers & SHIFT_MASK) != 0) {
-        modifiersSource += "java.awt.event.InputEvent.SHIFT_MASK | ";
+        modifiersSource += "java.awt.event.InputEvent.SHIFT_DOWN_MASK | ";
       }
       if ((modifiers & META_MASK) != 0) {
-        modifiersSource += "java.awt.event.InputEvent.META_MASK | ";
+        modifiersSource += "java.awt.event.InputEvent.META_DOWN_MASK | ";
       }
       if ((modifiers & ALT_GRAPH_MASK) != 0) {
-        modifiersSource += "java.awt.event.InputEvent.ALT_GRAPH_MASK | ";
+        modifiersSource += "java.awt.event.InputEvent.ALT_GRAPH_DOWN_MASK | ";
       }
       //
       if (modifiersSource.length() != 0) {


### PR DESCRIPTION
The generated code will be using InputEvent.<key>_DOWN_MASK instead which is equivalent to InputEvent.<key>_MASK, not deprecated and closes my own issue #38. Thanks to @wimjongman.