### PR TITLE
Adding default serial version UID

### DIFF
--- a/org.eclipse.wb.core.lib/src/org/mvel2/util/ParseTools.java
+++ b/org.eclipse.wb.core.lib/src/org/mvel2/util/ParseTools.java
@@ -1828,6 +1828,7 @@ public class ParseTools {
   }
 
   public static final class WithStatementPair implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
     private String parm;
     private String value;
 


### PR DESCRIPTION
Given my workspace configuration the missing serial version number gives
an error