### PR TITLE
Also remove TableTreeTest from Test suite

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/JFaceTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/JFaceTests.java
@@ -24,7 +24,6 @@ public class JFaceTests extends DesignerSuiteTests {
   public static Test suite() {
     TestSuite suite = new TestSuite("org.eclipse.wb.rcp.model.jface");
     suite.addTest(createSingleSuite(TableViewerTest.class));
-    suite.addTest(createSingleSuite(TableTreeViewerTest.class));
     suite.addTest(createSingleSuite(TableViewerColumnTest.class));
     suite.addTest(createSingleSuite(TreeViewerColumnTest.class));
     suite.addTest(createSingleSuite(ComboViewerTest.class));


### PR DESCRIPTION
e41ae02aff23f3ba599472c47ac4832ce29b3c06 removed the test but it was
still referred too in the test suite