### PR TITLE
Removes exit test which test the removed security manager exit

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/DesignerPluginTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/DesignerPluginTest.java
@@ -88,22 +88,6 @@ public class DesignerPluginTest extends DesignerTestCase {
     }
   }
 
-  ////////////////////////////////////////////////////////////////////////////
-  //
-  // Exit
-  //
-  ////////////////////////////////////////////////////////////////////////////
-  /**
-   * We should prevent {@link System#exit(int)} execution from within user-loaded code.
-   */
-  public void test_preventExit_execution() {
-    try {
-      System.exit(0);
-      fail();
-    } catch (SecurityException e) {
-    }
-  }
-
   /**
    * However we should allow {@link JFrame#setDefaultCloseOperation(int)} with
    * {@link JFrame#EXIT_ON_CLOSE}.


### PR DESCRIPTION
prevention

https://github.com/eclipse/windowbuilder/issues/42 removed the security
manager, but we left the corresponding test included.

For #42