### PR TITLE
Fixes PDE error for non-existing package export in

### DIFF
--- a/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
@@ -12,7 +12,6 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.wb.internal.core.preferences,
- org.eclipse.wb.internal.core.ui,
  org.eclipse.wb.internal.core.wizards.actions,
  org.eclipse.wb.internal.core.wizards.palette
 Automatic-Module-Name: org.eclipse.wb.core.ui


### PR DESCRIPTION
org.eclipse.wb.core.ui

Latest Eclipse release reports this as error.