### PR TITLE
Editor context menu basic UI

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignContextMenuProvider.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignContextMenuProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2022 Google, Inc and others
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,12 +7,14 @@
  *
  * Contributors:
  *    Google, Inc. - initial API and implementation
+ *    Marcel du Preez - adjusted buildContextMenu method to include version of context menu for Basic UI
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor;
 
 import com.google.common.collect.Lists;
 
 import org.eclipse.wb.core.editor.IContextMenuConstants;
+import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
@@ -22,6 +24,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.gef.core.ContextMenuProvider;
 import org.eclipse.wb.internal.gef.core.MultiSelectionContextMenuProvider;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
 
@@ -95,6 +98,10 @@ public final class DesignContextMenuProvider extends MultiSelectionContextMenuPr
   @Override
   protected void buildContextMenu(final EditPart editPart, final IMenuManager manager) {
     addGroups(manager);
+    boolean wbBasic = InstanceScope.INSTANCE.getNode(
+        IEditorPreferenceConstants.WB_BASIC_UI_PREFERENCE_NODE).getBoolean(
+            IEditorPreferenceConstants.WB_BASIC_UI,
+            false);
     // edit
     {
       manager.appendToGroup(IContextMenuConstants.GROUP_EDIT, m_pageActions.getCutAction());
@@ -104,18 +111,21 @@ public final class DesignContextMenuProvider extends MultiSelectionContextMenuPr
     }
     // edit2
     {
-      manager.appendToGroup(IContextMenuConstants.GROUP_EDIT2, m_pageActions.getTestAction());
-      manager.appendToGroup(IContextMenuConstants.GROUP_EDIT2, m_pageActions.getRefreshAction());
+      if (!wbBasic) {
+        manager.appendToGroup(IContextMenuConstants.GROUP_EDIT2, m_pageActions.getTestAction());
+        manager.appendToGroup(IContextMenuConstants.GROUP_EDIT2, m_pageActions.getRefreshAction());
+      }
     }
     // send notification
-    if (editPart.getModel() instanceof ObjectInfo) {
-      ExecutionUtils.runLog(new RunnableEx() {
-        @Override
-        public void run() throws Exception {
-          ObjectInfo object = (ObjectInfo) editPart.getModel();
-          object.getBroadcastObject().addContextMenu(m_selectedObjects, object, manager);
-        }
-      });
+    if (!wbBasic) {
+      if (editPart.getModel() instanceof ObjectInfo) {
+        ExecutionUtils.runLog(new RunnableEx() {
+          public void run() throws Exception {
+            ObjectInfo object = (ObjectInfo) editPart.getModel();
+            object.getBroadcastObject().addContextMenu(m_selectedObjects, object, manager);
+          }
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
Basic UI version of editor context menu created using the Basic WB UI preference.

Basic UI version of context editor contains only the Copy, paste, cut and delete option

Solution description: I have added preferences to the DesignContextMenuProvider class in the buildContextMenu method. These preferences are not available to the user but can be set by using the InstanceScope. The default for these preferences are set to true and therefore will always show all the actions as previously defined unless the developer incorporating windowbuilder into their product sets the preferences to false.

The two preferences are:

To hide the same actions as are found on the Windowbuilder toolbar, i.e. the Test and Refresh actions
To hide object specific actions that vary depending on which object the context menu is invoked
Following are screenshots of the context menu:
When preferences are set to true
![image](https://user-images.githubusercontent.com/92920738/166651885-a9d9445a-aef5-4bbd-ac56-e879ff3a368b.png)
When the toolbar preference is set to false
![image](https://user-images.githubusercontent.com/92920738/166651916-56a714ac-e47c-47a9-b895-7fd2b4146ed7.png)
When the object specific preference is set to false
![image](https://user-images.githubusercontent.com/92920738/166651953-87b33f62-1d49-48fa-a490-f966a1a6d4e6.png)
When both are set to false and only the basic actions remain
![image](https://user-images.githubusercontent.com/92920738/166652046-245cdf82-b5a3-4ce8-9251-75752c43a488.png)

