### PR TITLE
Set Layouts via Preference Page

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerPalette.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc and Others.
+ * Copyright (c) 2011, 2022 Google, Inc. and Others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.eclipse.wb.core.controls.palette.ICategory;
 import org.eclipse.wb.core.controls.palette.IEntry;
 import org.eclipse.wb.core.controls.palette.IPalette;
 import org.eclipse.wb.core.controls.palette.PaletteComposite;
+import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.core.editor.palette.PaletteEventListener;
 import org.eclipse.wb.core.editor.palette.model.CategoryInfo;
 import org.eclipse.wb.core.editor.palette.model.EntryInfo;
@@ -61,6 +62,7 @@ import org.eclipse.wb.internal.gef.core.IDefaultToolProvider;
 
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
@@ -90,6 +92,7 @@ public class DesignerPalette {
   // Instance fields
   //
   ////////////////////////////////////////////////////////////////////////////
+  private final String ENTRYINFO_CATEGORY = "org.eclipse.wb.swing.layouts";
   private final boolean m_isMainPalette;
   private final PluginPalettePreferences m_preferences;
   private final PaletteComposite m_paletteComposite;
@@ -336,9 +339,21 @@ public class DesignerPalette {
           List<IEntry> entries = Lists.newArrayList();
           for (EntryInfo entryInfo : entryInfoList) {
             if (entryInfo.isVisible()) {
-              IEntry entry = getVisualEntry(entryInfo);
-              if (entry != null) {
-                entries.add(entry);
+              if (categoryId.equals(ENTRYINFO_CATEGORY)) {
+                if (InstanceScope.INSTANCE.getNode(
+                    IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE).getBoolean(
+                        entryInfo.getId().substring(entryInfo.getId().indexOf(' ') + 1),
+                        true)) {
+                  IEntry entry = getVisualEntry(entryInfo);
+                  if (entry != null) {
+                    entries.add(entry);
+                  }
+                }
+              } else {
+                IEntry entry = getVisualEntry(entryInfo);
+                if (entry != null) {
+                  entries.add(entry);
+                }
               }
             }
           }

--- a/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/UiMessages.java
+++ b/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/UiMessages.java
@@ -6,6 +6,7 @@ public class UiMessages extends NLS {
   private static final String BUNDLE_NAME = "org.eclipse.wb.internal.core.UiMessages"; //$NON-NLS-1$
   public static String AbstractOpenWizardAction_emptyWorkspaceMessage;
   public static String AbstractOpenWizardAction_emptyWorkspaceTitle;
+  public static String LayoutsPreferencePage_availableLayouts;
   public static String LayoutsPreferencePage_defaultLayout;
   public static String LayoutsPreferencePage_implicitLayout;
   public static String LayoutsPreferencePage_inheritLayout;

--- a/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/UiMessages.properties
+++ b/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/UiMessages.properties
@@ -1,5 +1,6 @@
 AbstractOpenWizardAction_emptyWorkspaceMessage=A project must be created first
 AbstractOpenWizardAction_emptyWorkspaceTitle=No Projects
+LayoutsPreferencePage_availableLayouts=Layouts to use:
 LayoutsPreferencePage_defaultLayout=Default layout manager:
 LayoutsPreferencePage_implicitLayout=Implicit (default) layout
 LayoutsPreferencePage_inheritLayout=Containers automatically use layout manager type of parent

--- a/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/preferences/LayoutsPreferencePage.java
+++ b/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/preferences/LayoutsPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2022 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,9 +7,12 @@
  *
  * Contributors:
  *    Google, Inc. - initial API and implementation
+ *    Marcel du Preez - Added table to select available layouts
+ *                    - Override PerformOk to save preferences
  *******************************************************************************/
 package org.eclipse.wb.internal.core.preferences;
 
+import org.eclipse.wb.core.editor.constants.IEditorPreferenceConstants;
 import org.eclipse.wb.internal.core.UiMessages;
 import org.eclipse.wb.internal.core.model.description.LayoutDescription;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
@@ -23,14 +26,20 @@ import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableItem;
 
 import org.apache.commons.lang.StringUtils;
+import org.osgi.service.prefs.BackingStoreException;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -62,6 +71,16 @@ public abstract class LayoutsPreferencePage extends AbstractBindingPreferencesPa
     return new ContentsComposite(parent, m_bindManager, m_preferences);
   }
 
+  @Override
+  public boolean performOk() {
+    try {
+      InstanceScope.INSTANCE.getNode(IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE).flush();
+    } catch (BackingStoreException e) {
+      e.printStackTrace();
+    }
+    return super.performOk();
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   //
   // Contents
@@ -72,7 +91,8 @@ public abstract class LayoutsPreferencePage extends AbstractBindingPreferencesPa
         DataBindManager bindManager,
         IPreferenceStore preferences) {
       super(parent, bindManager, preferences);
-      GridLayoutFactory.create(this).noMargins().columns(2);
+      int gridLayoutColumns = 2;
+      GridLayoutFactory.create(this).noMargins().columns(gridLayoutColumns);
       // default layout
       {
         new Label(this, SWT.NONE).setText(UiMessages.LayoutsPreferencePage_defaultLayout);
@@ -94,6 +114,26 @@ public abstract class LayoutsPreferencePage extends AbstractBindingPreferencesPa
             layoutCombo.add(layoutDescription.getName());
           }
         }
+
+		layoutCombo.addSelectionListener(new SelectionListener() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				// If a layout is specified as a default layout but the layout is not specified
+				// to be available in the table
+				// the default layout is set back to implicit layout
+				int index = layoutCombo.getSelectionIndex();
+				LayoutDescription layout = layouts.get(index - 1);
+				if (!isLayoutAvailable(layout)) {
+					layoutCombo.select(0);
+				}
+			}
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+
+			}
+
+		});
         // bind
         m_bindManager.bind(new IDataEditor() {
           @Override
@@ -121,10 +161,44 @@ public abstract class LayoutsPreferencePage extends AbstractBindingPreferencesPa
               return null;
             } else {
               LayoutDescription layout = layouts.get(index - 1);
-              return layout.getId();
+					if (isLayoutAvailable(layout)) {
+						return layout.getId();
+					}
+					return null;
+
             }
           }
-        }, new StringPreferenceProvider(m_preferences, IPreferenceConstants.P_LAYOUT_DEFAULT), true);
+        },
+            new StringPreferenceProvider(m_preferences, IPreferenceConstants.P_LAYOUT_DEFAULT), true);
+        new Label(this, SWT.NONE).setText(UiMessages.LayoutsPreferencePage_availableLayouts);
+        Table table = new Table(this, SWT.CHECK | SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+        for (LayoutDescription layout : layouts) {
+          TableItem checkItem = new TableItem(table, SWT.NONE);
+          checkItem.setText(layout.getName());
+          checkItem.setData(layout);
+          checkItem.setChecked(
+              InstanceScope.INSTANCE.getNode(
+                  IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE).getBoolean(
+                      layout.getLayoutClassName(),
+                      true));
+        }
+        table.addListener(SWT.Selection, event -> {
+          if (event.detail == SWT.CHECK) {
+            InstanceScope.INSTANCE.getNode(
+                IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE).putBoolean(
+                    ((LayoutDescription) ((TableItem) event.item).getData()).getLayoutClassName(),
+                    ((TableItem) event.item).getChecked());
+          }
+			// If default was set to a layoiut that is deselcted from available layouts. The
+			// default layout is set back to implicit layout
+			if (!((TableItem) event.item).getChecked()
+					&& ((LayoutDescription) ((TableItem) event.item).getData()).getName()
+					.contentEquals(layoutCombo.getText())) {
+				layoutCombo.select(0);
+
+			}
+        });
+        GridDataFactory.create(table).fillH().spanH(gridLayoutColumns);
       }
       // boolean preferences
       checkButton(
@@ -134,4 +208,10 @@ public abstract class LayoutsPreferencePage extends AbstractBindingPreferencesPa
           IPreferenceConstants.P_LAYOUT_OF_PARENT);
     }
   }
+
+	private static boolean isLayoutAvailable(LayoutDescription layout) {
+		return InstanceScope.INSTANCE.getNode(IEditorPreferenceConstants.P_AVAILABLE_LAYOUTS_NODE)
+				.getBoolean(layout.getLayoutClassName(), false);
+
+	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/constants/IEditorPreferenceConstants.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/constants/IEditorPreferenceConstants.java
@@ -23,4 +23,12 @@ public interface IEditorPreferenceConstants {
   public static String WB_CLASSPATH_ICONS = "iconsClasspaths";
   //Sets the root object name in the Components Tree view
   public static String WB_ROOT_OBJ_NAME = "rootObjectDisplayName";
+  /**
+   * This node is used to store the preferences of which layouts should be available in
+   * Windowbuilder Swing and SWT layout preferences both use the same node. If the preferences on
+   * this node are <code>true</true> they
+   * will be available for use as normal. If it is <code>false</code> then the specified layouts
+   * will be hidden from layout comboxes as well as the layout container in the designer palette.
+   */
+  public static String P_AVAILABLE_LAYOUTS_NODE = "layout.available";
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/preferences/bind/AbstractBindingPreferencesPage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/preferences/bind/AbstractBindingPreferencesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2022 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *    Google, Inc. - initial API and implementation
+ *    Marcel du Preez - removed final from "performOk" 
  *******************************************************************************/
 package org.eclipse.wb.internal.core.preferences.bind;
 
@@ -88,7 +89,7 @@ public abstract class AbstractBindingPreferencesPage extends PreferencePage
   //
   ////////////////////////////////////////////////////////////////////////////
   @Override
-  public final boolean performOk() {
+  public boolean performOk() {
     if (!m_composite.performOk()) {
       return false;
     }

--- a/org.eclipse.wb.swing/plugin.xml
+++ b/org.eclipse.wb.swing/plugin.xml
@@ -463,6 +463,8 @@
 			class="java.awt.CardLayout"/>
 		<layout toolkit="org.eclipse.wb.swing" id="gridBagLayout" name="GridBagLayout"
 			class="java.awt.GridBagLayout"/>
+		<layout toolkit="org.eclipse.wb.swing" id="springLayout" name="SpringLayout"
+			class="javax.swing.SpringLayout"/> 
 	</extension>
 
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/ContainerEditPart.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/part/ContainerEditPart.java
@@ -96,7 +96,7 @@ public final class ContainerEditPart extends ComponentEditPart {
       if (m_currentLayout != layout) {
         m_currentLayout = layout;
         LayoutEditPolicy policy = LayoutPolicyUtils.createLayoutEditPolicy(this, layout);
-        installEditPolicy(EditPolicy.LAYOUT_ROLE, policy);
+		installEditPolicy(EditPolicy.LAYOUT_ROLE, policy);
       }
     }
   }

--- a/org.eclipse.wb.swing/templates/JFrame_advanced.jvt
+++ b/org.eclipse.wb.swing/templates/JFrame_advanced.jvt
@@ -33,7 +33,7 @@ method
 		setBounds(100, 100, %DefaultFormSize%);
 		%this%%field-prefix%contentPane = new JPanel();
 		%this%%field-prefix%contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
-		%this%%field-prefix%contentPane.setLayout(new BorderLayout(0, 0));
+		%ContentPane.SwingLayout%
 		setContentPane(%this%%field-prefix%contentPane);
 	}
 


### PR DESCRIPTION
This closes issue #181 

Users are now able to set the specific layouts they want to be made available in Windowbuilder. By default all layouts are available.
Following is a screenshot of the preference page in Swing:
![image](https://user-images.githubusercontent.com/92920738/162916671-06aeb2e7-9c6e-40f5-9810-50b26fa0db67.png)
Following is a screenshot of the preference page in SWT:
![image](https://user-images.githubusercontent.com/92920738/162916829-e6fb1c76-3791-4ae0-ab9d-59f30eacdd3f.png)

Below the preferences are set to only include the border layout, the UI changes can be seen in the layout group on the designer palette as well as in the context menu and layout dropwdown in the Properties view.
![image](https://user-images.githubusercontent.com/92920738/162917472-25fee1a1-4785-4393-bbb1-4ea3596908db.png)

![image](https://user-images.githubusercontent.com/92920738/162917237-aa435a2c-8263-42c6-9628-f5a85accb698.png)
![image](https://user-images.githubusercontent.com/92920738/162917308-db078e1c-9e90-4d4d-a652-ef2040ff2916.png)




