### PR TITLE
Code cleanup run to add missing annotations org.eclipse.wb.os.macosx

### DIFF
--- a/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSXCocoa.java
+++ b/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSXCocoa.java
@@ -158,6 +158,7 @@ public abstract class OSSupportMacOSXCocoa<H extends Number> extends OSSupportMa
     final Image[] toReturn = new Image[]{null};
     final Display display = DesignerPlugin.getStandardDisplay();
     display.syncExec(new Runnable() {
+      @Override
       public void run() {
         toReturn[0] = makeShotAwt0(display, component, width, height);
       }


### PR DESCRIPTION
Code cleanup run to add missing annotations:
@Override
@Override annotations to implementations of interface methods
@Deprecated