### PR TITLE
Code cleanup run to add missing annotations org.eclipse.wb.swing.java6

### DIFF
--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupSelectionEditPolicy.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/GroupSelectionEditPolicy.java
@@ -43,6 +43,7 @@ public final class GroupSelectionEditPolicy extends AbsoluteComplexSelectionEdit
   // Overrides
   //
   ////////////////////////////////////////////////////////////////////////////
+  @Override
   public Image getActionImage(String imageName) {
     return GroupLayoutInfo.getImage(imageName);
   }

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/LayoutEditPolicyFactory2.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/gef/LayoutEditPolicyFactory2.java
@@ -31,6 +31,7 @@ public final class LayoutEditPolicyFactory2 implements ILayoutEditPolicyFactory 
   // ILayoutEditPolicyFactory
   //
   ////////////////////////////////////////////////////////////////////////////
+  @Override
   public LayoutEditPolicy createLayoutEditPolicy(EditPart context, Object model) {
     if (model instanceof GroupLayoutInfo2) {
       if (!(((GroupLayoutInfo2) model).getCreationSupport() instanceof IImplicitCreationSupport)) {


### PR DESCRIPTION
Code cleanup run to add missing annotations:
@Override
@Override annotations to implementations of interface methods
@Deprecated