### PR TITLE
Document that org.eclipse.osgi.compatibility.state is required for

### DIFF
--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -64,6 +64,7 @@
 						<include>**/org.eclipse.wb.tests.designer.editor.EditorTests.java</include>
           			</includes>
 					<dependencies>
+					   <!-- required for PlatformAdmin to work-->
 						<dependency>
 							<type>eclipse-plugin</type>
 							<artifactId>org.eclipse.osgi.compatibility.state</artifactId>


### PR DESCRIPTION
PlatforAdmin service to work