### PR TITLE
Cleanup classpath in wb.tests

### DIFF
--- a/org.eclipse.wb.tests/.classpath
+++ b/org.eclipse.wb.tests/.classpath
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry exported="true" kind="lib" path="lib/EasyMock-3.0.jar" sourcepath="lib/EasyMock-3.0-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/objenesis-1.2.jar" sourcePath="lib/objenesis-1.2-sources.jar"/>
-	<classpathentry kind="lib" path="lib/org.assertj_1.7.1.v20170413-2026.jar" sourcepath="lib/org.assertj.source_1.7.1.v20170413-2026.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="lib" path="lib/org.assertj_1.7.1.v20170413-2026.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/objenesis-1.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/EasyMock-3.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Removes double entry in classpath if you press the "Update classpath"
button on the test MANIFEST.MF.