### PR TITLE
Replacing Guava Maps with regular HashMap wb.core

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -11,13 +11,13 @@
 package org.eclipse.wb.internal.draw2d;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.draw2d.geometry.Dimension;
 import org.eclipse.wb.draw2d.geometry.Rectangle;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +30,7 @@ public class RootFigure extends Figure implements IRootFigure {
   private final RefreshManager m_refreshManager;
   private EventManager m_eventManager;
   private Dimension m_preferredSize;
-  private Map<String, Layer> m_nameToLayer = Maps.newHashMap();
+  private Map<String, Layer> m_nameToLayer = new HashMap<>();
   private IPreferredSizeProvider m_preferredSizeProvider;
 
   ////////////////////////////////////////////////////////////////////////////
@@ -216,7 +216,7 @@ public class RootFigure extends Figure implements IRootFigure {
    */
   @Override
   public void removeAll() {
-    m_nameToLayer = Maps.newHashMap();
+    m_nameToLayer = new HashMap<>();
     super.removeAll();
   }
 }

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/events/EventTable.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/events/EventTable.java
@@ -11,10 +11,10 @@
 package org.eclipse.wb.internal.draw2d.events;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +23,7 @@ import java.util.Map;
  * @coverage gef.draw2d
  */
 public class EventTable {
-  private final Map<Class<?>, List<?>> m_listenerClassToListener = Maps.newHashMap();
+  private final Map<Class<?>, List<?>> m_listenerClassToListener = new HashMap<>();
 
   ////////////////////////////////////////////////////////////////////////////
   //

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.gef.core;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.gef.core.events.IEditPartListener;
 import org.eclipse.wb.gef.core.events.IEditPartSelectionListener;
@@ -29,6 +28,7 @@ import org.eclipse.wb.internal.gef.core.IRootContainer;
 import org.eclipse.core.runtime.Assert;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -395,7 +395,7 @@ public abstract class EditPart {
 
   protected void refreshChildren() {
     // prepare map[model, currentPart]
-    Map<Object, EditPart> modelToPart = Maps.newHashMap();
+    Map<Object, EditPart> modelToPart = new HashMap<>();
     List<EditPart> children = getChildren();
     for (EditPart editPart : children) {
       modelToPart.put(editPart.getModel(), editPart);

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/requests/Request.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/requests/Request.java
@@ -10,12 +10,11 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core.requests;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.gef.core.EditPart;
 
 import org.eclipse.swt.SWT;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -269,7 +268,7 @@ public class Request {
    */
   public final void putArbitraryValue(Object key, Object value) {
     if (m_arbitraryMap == null) {
-      m_arbitraryMap = Maps.newHashMap();
+      m_arbitraryMap = new HashMap<>();
     }
     m_arbitraryMap.put(key, value);
   }

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/core/AbstractEditPartViewer.java
@@ -12,7 +12,6 @@
 package org.eclipse.wb.internal.gef.core;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartFactory;
@@ -30,6 +29,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Menu;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +43,7 @@ public abstract class AbstractEditPartViewer implements IEditPartViewer {
   private/*final*/IRootContainer m_rootEditPart;
   private EditDomain m_domain;
   private IEditPartFactory m_factory;
-  private final Map<Object, EditPart> m_modelToEditPart = Maps.newHashMap();
+  private final Map<Object, EditPart> m_modelToEditPart = new HashMap<>();
   private MenuManager m_contextMenu;
   private List<EditPart> m_selectionList = Lists.newArrayList();
   private EventTable m_eventTable;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.controls.palette;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 import org.eclipse.wb.draw2d.Graphics;
@@ -19,7 +17,6 @@ import org.eclipse.wb.draw2d.IColorConstants;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.draw2d.events.IMouseListener;
-import org.eclipse.wb.draw2d.events.IMouseMoveListener;
 import org.eclipse.wb.draw2d.events.IMouseTrackListener;
 import org.eclipse.wb.draw2d.events.MouseEvent;
 import org.eclipse.wb.draw2d.geometry.Dimension;
@@ -32,7 +29,6 @@ import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.TargetFigureFindVisitor;
 
 import org.eclipse.jface.action.Action;
-import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.SWT;
@@ -41,9 +37,8 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -104,7 +99,7 @@ public final class PaletteComposite extends Composite {
   private final GC m_paletteGC;
   private final PaletteFigure m_paletteFigure;
   private final Layer m_feedbackLayer;
-  private final Map<ICategory, CategoryFigure> m_categoryFigures = Maps.newHashMap();
+  private final Map<ICategory, CategoryFigure> m_categoryFigures = new HashMap<>();
   private MenuManager m_menuManager;
   private IPalette m_palette;
   private IEntry m_selectedEntry;
@@ -129,12 +124,7 @@ public final class PaletteComposite extends Composite {
     // prepare GC (for layout)
     {
       m_paletteGC = new GC(m_figureCanvas);
-      addListener(SWT.Dispose, new Listener() {
-        @Override
-        public void handleEvent(Event event) {
-          m_paletteGC.dispose();
-        }
-      });
+      addListener(SWT.Dispose, event -> m_paletteGC.dispose());
     }
     // add palette figure (layer)
     m_paletteFigure = new PaletteFigure();
@@ -144,12 +134,7 @@ public final class PaletteComposite extends Composite {
       m_menuManager = new MenuManager();
       m_menuManager.setRemoveAllWhenShown(true);
       m_figureCanvas.setMenu(m_menuManager.createContextMenu(m_figureCanvas));
-      m_menuManager.addMenuListener(new IMenuListener() {
-        @Override
-        public void menuAboutToShow(IMenuManager manager) {
-          addPopupActions(manager);
-        }
-      });
+      m_menuManager.addMenuListener(manager -> addPopupActions(manager));
     }
     // add feedback layer
     {
@@ -357,7 +342,7 @@ public final class PaletteComposite extends Composite {
     //
     ////////////////////////////////////////////////////////////////////////////
     private final ICategory m_category;
-    private final Map<IEntry, EntryFigure> m_entryFigures = Maps.newHashMap();
+    private final Map<IEntry, EntryFigure> m_entryFigures = new HashMap<>();
     private int m_columns;
     private int m_titleHeight;
 
@@ -450,25 +435,22 @@ public final class PaletteComposite extends Composite {
           repaint();
         }
       });
-      addMouseMoveListener(new IMouseMoveListener() {
-        @Override
-        public void mouseMove(MouseEvent event) {
-          if (m_mouseDown) {
-            Point p = new Point(event.x, event.y);
-            // update moving
-            if (!m_moving && m_downPoint.getDistance(p) > 4) {
-              m_moving = true;
-            }
-            // show feedback
-            if (m_moving) {
-              move_showFeedback(p);
-            }
-          } else {
-            m_mouseOnTitle = getTitleRectangle().contains(event.x, event.y);
-            repaint();
-          }
-        }
-      });
+      addMouseMoveListener(event -> {
+	  if (m_mouseDown) {
+	    Point p = new Point(event.x, event.y);
+	    // update moving
+	    if (!m_moving && m_downPoint.getDistance(p) > 4) {
+	      m_moving = true;
+	    }
+	    // show feedback
+	    if (m_moving) {
+	      move_showFeedback(p);
+	    }
+	  } else {
+	    m_mouseOnTitle = getTitleRectangle().contains(event.x, event.y);
+	    repaint();
+	  }
+	});
       addMouseTrackListener(new IMouseTrackListener() {
         @Override
         public void mouseEnter(MouseEvent e) {
@@ -788,28 +770,25 @@ public final class PaletteComposite extends Composite {
           repaint();
         }
       });
-      addMouseMoveListener(new IMouseMoveListener() {
-        @Override
-        public void mouseMove(MouseEvent event) {
-          // update mouse location
-          boolean oldMouseInside = m_mouseInside;
-          m_mouseInside = getClientArea().contains(event.x, event.y);
-          //
-          if (m_mouseDown) {
-            Point p = new Point(event.x, event.y);
-            // update moving
-            if (!m_moving && m_downPoint.getDistance(p) > 4) {
-              m_moving = true;
-            }
-            // show feedback
-            if (m_moving) {
-              move_showFeedback(p);
-            }
-          } else if (m_mouseInside != oldMouseInside) {
-            repaint();
-          }
-        }
-      });
+      addMouseMoveListener(event -> {
+	  // update mouse location
+	  boolean oldMouseInside = m_mouseInside;
+	  m_mouseInside = getClientArea().contains(event.x, event.y);
+	  //
+	  if (m_mouseDown) {
+	    Point p = new Point(event.x, event.y);
+	    // update moving
+	    if (!m_moving && m_downPoint.getDistance(p) > 4) {
+	      m_moving = true;
+	    }
+	    // show feedback
+	    if (m_moving) {
+	      move_showFeedback(p);
+	    }
+	  } else if (m_mouseInside != oldMouseInside) {
+	    repaint();
+	  }
+	});
       addMouseTrackListener(new IMouseTrackListener() {
         @Override
         public void mouseEnter(MouseEvent e) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CachingLayoutRequestValidator.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/validator/CachingLayoutRequestValidator.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.validator;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.policies.ILayoutRequestValidator;
 import org.eclipse.wb.gef.core.requests.ChangeBoundsRequest;
@@ -19,6 +17,7 @@ import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.gef.core.requests.Request;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -100,7 +99,7 @@ public final class CachingLayoutRequestValidator implements ILayoutRequestValida
   private Map<EditPart, Boolean> getCache(Request request) {
     Map<EditPart, Boolean> cache = (Map<EditPart, Boolean>) request.getArbitraryValue(this);
     if (cache == null) {
-      cache = Maps.newHashMap();
+      cache = new HashMap<>();
       request.putArbitraryValue(this, cache);
     }
     return cache;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/ObjectInfo.java
@@ -13,7 +13,6 @@ package org.eclipse.wb.core.model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.core.model.broadcast.BroadcastSupport;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
@@ -27,10 +26,9 @@ import org.eclipse.wb.internal.core.utils.GenericsUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import java.util.Collections;
-import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -268,12 +266,7 @@ public abstract class ObjectInfo implements IObjectInfo {
    * Visits this {@link ObjectInfo} and its children using given {@link ObjectInfoVisitor}.
    */
   public final void accept(final ObjectInfoVisitor visitor) {
-    ExecutionUtils.runRethrow(new RunnableEx() {
-      @Override
-      public void run() throws Exception {
-        accept0(visitor);
-      }
-    });
+    ExecutionUtils.runRethrow(() -> accept0(visitor));
   }
 
   /**
@@ -349,12 +342,7 @@ public abstract class ObjectInfo implements IObjectInfo {
    * @return the {@link ObjectEventListener} for hierarchy.
    */
   public final ObjectEventListener getBroadcastObject() {
-    return ExecutionUtils.runObject(new RunnableObjectEx<ObjectEventListener>() {
-      @Override
-      public ObjectEventListener runObject() throws Exception {
-        return getBroadcastSupport().getListener(ObjectEventListener.class);
-      }
-    });
+    return ExecutionUtils.runObject(() -> getBroadcastSupport().getListener(ObjectEventListener.class));
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -376,12 +364,7 @@ public abstract class ObjectInfo implements IObjectInfo {
    * Do properties sorting. Default implementation sorts properties by title alphabetically.
    */
   protected void sortPropertyList(List<Property> properties) {
-    Collections.sort(properties, new Comparator<Property>() {
-      @Override
-      public int compare(Property o1, Property o2) {
-        return o1.getTitle().compareTo(o2.getTitle());
-      }
-    });
+    Collections.sort(properties, (o1, o2) -> o1.getTitle().compareTo(o2.getTitle()));
   }
 
   /**
@@ -490,30 +473,12 @@ public abstract class ObjectInfo implements IObjectInfo {
     // clean up broadcast
     getBroadcastSupport().cleanUpTargets(ObjectInfo.this);
     // do refresh
-    execRefreshOperation(new RunnableEx() {
-      @Override
-      public void run() throws Exception {
-        ExecutionUtils.runDesignTime(new RunnableEx() {
-          @Override
-          public void run() throws Exception {
-            refreshCreate0();
-          }
-        });
-      }
-    });
+    execRefreshOperation(() -> ExecutionUtils.runDesignTime(() -> refreshCreate0()));
     // split fetch operations into separate parts
-    execRefreshOperation(new RunnableEx() {
-      @Override
-      public void run() throws Exception {
-        ExecutionUtils.runDesignTime(new RunnableEx() {
-          @Override
-          public void run() throws Exception {
-            refresh_fetch();
-            refresh_finish();
-          }
-        });
-      }
-    });
+    execRefreshOperation(() -> ExecutionUtils.runDesignTime(() -> {
+	    refresh_fetch();
+	    refresh_finish();
+	  }));
     // send notifications
     if (getArbitraryValue(KEY_NO_REFRESHED_BROADCAST) != Boolean.FALSE) {
       getBroadcastObject().refreshed();
@@ -535,28 +500,8 @@ public abstract class ObjectInfo implements IObjectInfo {
   public final void refreshLight() throws Exception {
     Assert.isLegal(isRoot());
     // do refresh
-    execRefreshOperation(new RunnableEx() {
-      @Override
-      public void run() throws Exception {
-        ExecutionUtils.runDesignTime(new RunnableEx() {
-          @Override
-          public void run() throws Exception {
-            refreshCreate0();
-          }
-        });
-      }
-    });
-    execRefreshOperation(new RunnableEx() {
-      @Override
-      public void run() throws Exception {
-        ExecutionUtils.runDesignTime(new RunnableEx() {
-          @Override
-          public void run() throws Exception {
-            refresh_finish();
-          }
-        });
-      }
-    });
+    execRefreshOperation(() -> ExecutionUtils.runDesignTime(() -> refreshCreate0()));
+    execRefreshOperation(() -> ExecutionUtils.runDesignTime(() -> refresh_finish()));
   }
 
   /**
@@ -690,7 +635,7 @@ public abstract class ObjectInfo implements IObjectInfo {
    */
   public final void putArbitraryValue(Object key, Object value) {
     if (m_arbitraryMap == null) {
-      m_arbitraryMap = Maps.newHashMap();
+      m_arbitraryMap = new HashMap<>();
     }
     m_arbitraryMap.put(key, value);
   }
@@ -720,7 +665,7 @@ public abstract class ObjectInfo implements IObjectInfo {
   public final Map<Object, Object> getArbitraries() {
     Map<Object, Object> arbitraries;
     if (m_arbitraryMap != null) {
-      arbitraries = Maps.newHashMap(m_arbitraryMap);
+      arbitraries = new HashMap<>(m_arbitraryMap);
     } else {
       arbitraries = ImmutableMap.of();
     }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/model/broadcast/BroadcastSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/model/broadcast/BroadcastSupport.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.core.model.broadcast;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
@@ -23,6 +22,7 @@ import net.sf.cglib.proxy.MethodProxy;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,11 +39,11 @@ public final class BroadcastSupport {
   /**
    * {@link Map} for "listener class" -> "listener implementations".
    */
-  private final Map<Class<?>, List<Object>> m_classToListeners = Maps.newHashMap();
+  private final Map<Class<?>, List<Object>> m_classToListeners = new HashMap<>();
   /**
    * {@link Map} for "listener target" -> "listener implementations".
    */
-  private final Map<ObjectInfo, List<Object>> m_targetToListeners = Maps.newHashMap();
+  private final Map<ObjectInfo, List<Object>> m_targetToListeners = new HashMap<>();
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -186,7 +186,7 @@ public final class BroadcastSupport {
   // Sending
   //
   ////////////////////////////////////////////////////////////////////////////
-  private final Map<Class<?>, Object> m_listenerToMulticast = Maps.newHashMap();
+  private final Map<Class<?>, Object> m_listenerToMulticast = new HashMap<>();
 
   /**
    * @return the implementation of given listener class (so it can be casted to it) that can be used

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
@@ -34,7 +34,6 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 
 import static org.burningwave.core.assembler.StaticComponentContainer.Modules;
 
-import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.BundleContext;
 
 import java.io.InputStream;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteBasedLayoutEditPolicy.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.gef.policy.layout.absolute;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.core.gef.command.CompoundEditCommand;
 import org.eclipse.wb.core.gef.command.EditCommand;
@@ -54,7 +53,6 @@ import org.eclipse.wb.internal.core.gef.policy.snapping.PlacementsSupport;
 import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.model.layout.absolute.IPreferenceConstants;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
-import org.eclipse.wb.internal.core.utils.state.IPasteComponentProcessor;
 import org.eclipse.wb.internal.gef.core.CompoundCommand;
 
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -62,6 +60,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -375,7 +374,7 @@ public abstract class AbsoluteBasedLayoutEditPolicy<C extends IAbstractComponent
     Figure hostFigure = getHostFigure();
     if (m_dotsFeedback == null) {
       if ((useGridSnapping() || isKeyboardMoving()) && isShowGridFeedback()) {
-        m_dotsFeedback = new DotsFeedback<C>(this, hostFigure);
+        m_dotsFeedback = new DotsFeedback<>(this, hostFigure);
         addFeedback(m_dotsFeedback);
       }
     }
@@ -548,7 +547,7 @@ public abstract class AbsoluteBasedLayoutEditPolicy<C extends IAbstractComponent
     // create dots feedback
     if (m_dotsFeedback == null) {
       if (useGridSnapping() || isKeyboardMoving) {
-        m_dotsFeedback = new DotsFeedback<C>(this, getHost().getFigure());
+        m_dotsFeedback = new DotsFeedback<>(this, getHost().getFigure());
         addFeedback(m_dotsFeedback);
       }
     }
@@ -668,7 +667,7 @@ public abstract class AbsoluteBasedLayoutEditPolicy<C extends IAbstractComponent
     // create dots feedback
     if (m_dotsFeedback == null) {
       if (useGridSnapping() || isKeyboardMoving()) {
-        m_dotsFeedback = new DotsFeedback<C>(this, hostFigure);
+        m_dotsFeedback = new DotsFeedback<>(this, hostFigure);
         addFeedback(m_dotsFeedback);
       }
     }
@@ -712,9 +711,9 @@ public abstract class AbsoluteBasedLayoutEditPolicy<C extends IAbstractComponent
   private void showPasteFeedback(final PasteRequest request) {
     List<IObjectInfo> pastingComponents =
         GlobalState.getPasteRequestProcessor().getPastingComponents(request);
-    m_pastedComponents = Maps.newHashMap();
+    m_pastedComponents = new HashMap<>();
     List<IAbstractComponentInfo> pastedModels =
-        new ArrayList<IAbstractComponentInfo>(pastingComponents.size());
+        new ArrayList<>(pastingComponents.size());
     try {
       // remove create feedback
       if (m_createFeedback != null) {
@@ -777,7 +776,7 @@ public abstract class AbsoluteBasedLayoutEditPolicy<C extends IAbstractComponent
       // create dots feedback
       if (m_dotsFeedback == null) {
         if (useGridSnapping() || isKeyboardMoving()) {
-          m_dotsFeedback = new DotsFeedback<C>(this, getHostFigure());
+          m_dotsFeedback = new DotsFeedback<>(this, getHostFigure());
           addFeedback(m_dotsFeedback);
         }
       }
@@ -801,12 +800,7 @@ public abstract class AbsoluteBasedLayoutEditPolicy<C extends IAbstractComponent
     Command pasteCommand =
         GlobalState.getPasteRequestProcessor().getPasteCommand(
             request,
-            new IPasteComponentProcessor() {
-              @Override
-              public void process(Object component) throws Exception {
-                doPasteComponent(m_pasteLocation, m_pastedComponents.get(component));
-              }
-            });
+            component -> doPasteComponent(m_pasteLocation, m_pastedComponents.get(component)));
     EditCommand cleanupCommand = new EditCommand(m_layout) {
       @Override
       protected void executeEdit() throws Exception {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/IAbsoluteLayoutCommands.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/IAbsoluteLayoutCommands.java
@@ -13,6 +13,8 @@ package org.eclipse.wb.internal.core.gef.policy.snapping;
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.draw2d.IPositionConstants;
 
+import javax.swing.LayoutStyle;
+
 /**
  * Intended for {@link PlacementsSupport} to operate with layout.
  *

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/PlacementsSupport.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/snapping/PlacementsSupport.java
@@ -12,7 +12,6 @@ package org.eclipse.wb.internal.core.gef.policy.snapping;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
@@ -52,8 +51,8 @@ public final class PlacementsSupport {
 	private final PlacementInfo m_x = new PlacementInfo();
 	private final PlacementInfo m_y = new PlacementInfo();
 	private Rectangle m_bounds;
-	private final Map<IAbstractComponentInfo, Rectangle> m_newModelBounds = Maps.newHashMap();
-	private final Map<IAbstractComponentInfo, Rectangle> m_oldModelBounds = Maps.newHashMap();
+	private final Map<IAbstractComponentInfo, Rectangle> m_newModelBounds = new HashMap<>();
+	private final Map<IAbstractComponentInfo, Rectangle> m_oldModelBounds = new HashMap<>();
 	private final Map<IAbstractComponentInfo, Integer[]> m_effectiveAlignments = new HashMap<>();
 	private final IAbsoluteLayoutCommands m_layoutCommands;
 	private int m_resizeDirection;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/Property.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/Property.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.utils.IAdaptable;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -155,7 +154,7 @@ public abstract class Property implements IAdaptable {
    */
   public final void putArbitraryValue(Object key, Object value) {
     if (m_arbitraryMap == null) {
-      m_arbitraryMap = Maps.newHashMap();
+      m_arbitraryMap = new HashMap<>();
     }
     m_arbitraryMap.put(key, value);
   }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/PropertyManager.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/PropertyManager.java
@@ -16,14 +16,13 @@ import org.eclipse.wb.internal.core.model.description.ToolkitDescription;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 import org.eclipse.wb.internal.core.utils.base64.Base64Utils;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -104,7 +103,7 @@ public final class PropertyManager {
   //
   ////////////////////////////////////////////////////////////////////////////
   private static final Map<ToolkitDescription, Map<String, PropertyCategory>> m_toolkitCategories =
-      Maps.newHashMap();
+      new HashMap<>();
   public static void flushCache() {
     m_toolkitCategories.clear();
   }
@@ -117,21 +116,11 @@ public final class PropertyManager {
     return categories;
   }
   private static Map<String, PropertyCategory> loadCategories(final ToolkitDescription toolkit) {
-    return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Map<String, PropertyCategory>>() {
-      @Override
-      public Map<String, PropertyCategory> runObject() throws Exception {
-        return loadCategories0(toolkit);
-      }
-    }, Maps.<String, PropertyCategory>newTreeMap());
+    return ExecutionUtils.runObjectIgnore(() -> loadCategories0(toolkit), Maps.<String, PropertyCategory>newTreeMap());
   }
   private static void saveCategories(final ToolkitDescription toolkit,
       final Map<String, PropertyCategory> categories) {
-    ExecutionUtils.runLog(new RunnableEx() {
-      @Override
-      public void run() throws Exception {
-        saveCategories0(toolkit, categories);
-      }
-    });
+    ExecutionUtils.runLog(() -> saveCategories0(toolkit, categories));
   }
   @SuppressWarnings("unchecked")
   private static Map<String, PropertyCategory> loadCategories0(ToolkitDescription toolkit)

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/presentation/ButtonPropertyEditorPresentationImpl.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.editor.presentation;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
 import org.eclipse.wb.internal.core.utils.Pair;
@@ -20,9 +18,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -99,39 +96,23 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
     Control control = createControlImpl(propertyTable, property);
     m_propertyToControl.put(propertyTable, property, control);
     // when Control disposed, remove Control/Property from map to avoid memory leak
-    control.addListener(SWT.Dispose, new Listener() {
-      @Override
-      public void handleEvent(Event e) {
-        m_propertyToControl.remove(propertyTable, property);
-      }
-    });
+    control.addListener(SWT.Dispose, e -> m_propertyToControl.remove(propertyTable, property));
     // activate property on mouse down
-    control.addListener(SWT.MouseDown, new Listener() {
-      @Override
-      public void handleEvent(Event event) {
+    control.addListener(SWT.MouseDown, event -> {
         propertyTable.deactivateEditor(true);
         propertyTable.setActiveProperty(property);
-      }
-    });
+      });
     // return focus on propertyTable after click
-    control.addListener(SWT.MouseUp, new Listener() {
-      @Override
-      public void handleEvent(Event event) {
-        propertyTable.forceFocus();
-      }
-    });
+    control.addListener(SWT.MouseUp, event -> propertyTable.forceFocus());
     // handle selection
-    control.addListener(SWT.Selection, new Listener() {
-      @Override
-      public void handleEvent(Event event) {
+    control.addListener(SWT.Selection, event -> {
         try {
           getPresentation().onClick(propertyTable, property);
         } catch (Throwable e) {
           propertyTable.deactivateEditor(false);
           propertyTable.handleException(e);
         }
-      }
-    });
+      });
     return control;
   }
 
@@ -208,7 +189,7 @@ class ButtonPropertyEditorPresentationImpl extends PropertyEditorPresentation {
   //
   ////////////////////////////////////////////////////////////////////////////
   protected static final class PropertyToControlMap {
-    private final Map<Pair<PropertyTable, Property>, Control> m_map = Maps.newHashMap();
+    private final Map<Pair<PropertyTable, Property>, Control> m_map = new HashMap<>();
 
     void put(PropertyTable propertyTable, Property property, Control control) {
       m_map.put(Pair.create(propertyTable, property), control);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ScriptUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ScriptUtils.java
@@ -24,6 +24,7 @@ import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -53,7 +54,7 @@ public final class ScriptUtils {
       String script,
       String name_1,
       Object value_1) {
-    Map<String, Object> variables = Maps.newHashMap();
+    Map<String, Object> variables = new HashMap<>();
     variables.put(name_1, value_1);
     return evaluate(contextClassLoader, script, variables);
   }
@@ -67,7 +68,7 @@ public final class ScriptUtils {
       Object value_1,
       String name_2,
       Object value_2) {
-    Map<String, Object> variables = Maps.newHashMap();
+    Map<String, Object> variables = new HashMap<>();
     variables.put(name_1, value_1);
     variables.put(name_2, value_2);
     return evaluate(contextClassLoader, script, variables);
@@ -113,7 +114,7 @@ public final class ScriptUtils {
    */
   public static Object evaluate(String script, String name_1, Object value_1) {
     Object expression = compile(script);
-    Map<String, Object> variables = Maps.newHashMap();
+    Map<String, Object> variables = new HashMap<>();
     variables.put(name_1, value_1);
     return evaluate(expression, variables);
   }
@@ -127,7 +128,7 @@ public final class ScriptUtils {
       String name_2,
       Object value_2) {
     Object expression = compile(script);
-    Map<String, Object> variables = Maps.newHashMap();
+    Map<String, Object> variables = new HashMap<>();
     variables.put(name_1, value_1);
     variables.put(name_2, value_2);
     return evaluate(expression, variables);
@@ -203,7 +204,7 @@ public final class ScriptUtils {
     Class<ScriptUtils> key = ScriptUtils.class;
     Map<String, Object> cache = (Map<String, Object>) ClassLoaderLocalMap.get(context, key);
     if (cache == null) {
-      cache = Maps.newHashMap();
+      cache = new HashMap<>();
       ClassLoaderLocalMap.put(context, key, cache);
     }
     return cache;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/GenericTypeResolver.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/GenericTypeResolver.java
@@ -21,6 +21,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,7 +104,7 @@ public class GenericTypeResolver {
       Class<?> currentClass,
       Type[] arguments) {
     // Prepare map of current Class type parameters to arguments.
-    Map<String, Type> currentArguments = Maps.newHashMap();
+    Map<String, Type> currentArguments = new HashMap<>();
     TypeVariable<?>[] typeParameters = currentClass.getTypeParameters();
     for (int i = 0; i < typeParameters.length; i++) {
       TypeVariable<?> typeParameter = typeParameters[i];

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/external/ExternalFactoriesHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/external/ExternalFactoriesHelper.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.utils.external;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.wb.internal.core.BundleResourceProvider;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
@@ -33,6 +32,7 @@ import org.osgi.framework.Bundle;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -89,9 +89,9 @@ public class ExternalFactoriesHelper {
 	// Caching and reloading
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static Map<String, List<IExtension>> m_extensions = Maps.newHashMap();
-	private static Map<String, Map<String, List<IConfigurationElement>>> m_configurationElements = Maps.newHashMap();
-	private static Map<String, Map<String, List<?>>> m_configurationObjects = Maps.newHashMap();
+	private static Map<String, List<IExtension>> m_extensions = new HashMap<>();
+	private static Map<String, Map<String, List<IConfigurationElement>>> m_configurationElements = new HashMap<>();
+	private static Map<String, Map<String, List<?>>> m_configurationObjects = new HashMap<>();
 
 	/**
 	 * Clears caches in this helper.
@@ -143,7 +143,7 @@ public class ExternalFactoriesHelper {
 		// prepare: elementName -> List<?>
 		Map<String, List<?>> elementName_to_objects = m_configurationObjects.get(pointId);
 		if (elementName_to_objects == null) {
-			elementName_to_objects = Maps.newHashMap();
+			elementName_to_objects = new HashMap<>();
 			m_configurationObjects.put(pointId, elementName_to_objects);
 		}
 		// check for cached: List<?>
@@ -200,7 +200,7 @@ public class ExternalFactoriesHelper {
 		// prepare: elementName -> List<IConfigurationElement>
 		Map<String, List<IConfigurationElement>> elementName_to_elements = m_configurationElements.get(pointId);
 		if (elementName_to_elements == null) {
-			elementName_to_elements = Maps.newHashMap();
+			elementName_to_elements = new HashMap<>();
 			m_configurationElements.put(pointId, elementName_to_elements);
 		}
 		// check for cached: List<IConfigurationElement>

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/reflect/ReflectionUtils.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Sets;
 import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
-import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
@@ -42,6 +41,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -204,7 +204,7 @@ public class ReflectionUtils {
       return Sets.newHashSet();
     }
     if (isSuccessorOf(clazz, "java.util.Map")) {
-      return Maps.newHashMap();
+      return new HashMap<>();
     }
     // Object
     return null;
@@ -262,14 +262,14 @@ public class ReflectionUtils {
   }
 
   private static final Map<String, WeakHashMap<Class<?>, IsSuccessorResult>> m_isSuccessorOfCache =
-      Maps.newHashMap();
+      new HashMap<>();
 
   private static void isSuccessorOf_addCache(Class<?> clazz,
       String requiredClass,
       IsSuccessorResult result) {
     WeakHashMap<Class<?>, IsSuccessorResult> classes = m_isSuccessorOfCache.get(requiredClass);
     if (classes == null) {
-      classes = new WeakHashMap<Class<?>, IsSuccessorResult>();
+      classes = new WeakHashMap<>();
       m_isSuccessorOfCache.put(requiredClass, classes);
     }
     classes.put(clazz, result);
@@ -345,12 +345,7 @@ public class ReflectionUtils {
    */
   public static boolean isMemberClass(final Class<?> clazz) {
     Assert.isNotNull(clazz);
-    return ExecutionUtils.runObjectIgnore(new RunnableObjectEx<Boolean>() {
-      @Override
-      public Boolean runObject() throws Exception {
-        return clazz.isMemberClass();
-      }
-    }, false);
+    return ExecutionUtils.runObjectIgnore(() -> clazz.isMemberClass(), false);
   }
 
   /**
@@ -688,7 +683,7 @@ public class ReflectionUtils {
    * @return all declared {@link Method}'s, including protected and private.
    */
   public static Map<String, Method> getMethods(Class<?> clazz) {
-    Map<String, Method> methods = Maps.newHashMap();
+    Map<String, Method> methods = new HashMap<>();
     // process classes
     for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
       for (Method method : c.getDeclaredMethods()) {
@@ -1232,9 +1227,7 @@ public class ReflectionUtils {
   public static Object getFieldObject(final Object object, final String name) {
     Assert.isNotNull(object);
     Assert.isNotNull(name);
-    return ExecutionUtils.runObject(new RunnableObjectEx<Object>() {
-      @Override
-      public Object runObject() throws Exception {
+    return ExecutionUtils.runObject(() -> {
         Class<?> refClass = getRefClass(object);
         Object refObject = getRefObject(object);
         Field field = getFieldByName(refClass, name);
@@ -1242,8 +1235,7 @@ public class ReflectionUtils {
           throw new IllegalArgumentException("Unable to find '" + name + "' in " + refClass);
         }
         return field.get(refObject);
-      }
-    });
+      });
   }
 
   /**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/ui/UiUtils.java
@@ -11,7 +11,6 @@
 package org.eclipse.wb.internal.core.utils.ui;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -44,6 +43,7 @@ import org.eclipse.swt.widgets.Widget;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.ObjectUtils;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -115,12 +115,7 @@ public class UiUtils {
     menu.addMenuListener(new MenuAdapter() {
       @Override
       public void menuHidden(MenuEvent e) {
-        e.display.asyncExec(new Runnable() {
-          @Override
-          public void run() {
-            menu.dispose();
-          }
-        });
+        e.display.asyncExec(() -> menu.dispose());
       }
     });
     menu.setVisible(true);
@@ -245,9 +240,7 @@ public class UiUtils {
     final String TAB_ITEM_KEY = "_TABLEITEM";
     final Shell tableShell = table.getShell();
     //
-    final Listener tipControlListener = new Listener() {
-      @Override
-      public void handleEvent(Event event) {
+    final Listener tipControlListener = event -> {
         Control tipControl = (Control) event.widget;
         Shell tipShell = tipControl.getShell();
         switch (event.type) {
@@ -265,8 +258,7 @@ public class UiUtils {
             tipShell.dispose();
             break;
         }
-      }
-    };
+      };
     //
     Listener tableListener = new Listener() {
       private Shell m_tipShell = null;
@@ -572,7 +564,7 @@ public class UiUtils {
   // File icons
   //
   ////////////////////////////////////////////////////////////////////////////
-  private static Map<String, Image> m_extensionToIcon = Maps.newHashMap();
+  private static Map<String, Image> m_extensionToIcon = new HashMap<>();
 
   /**
    * @return icon that is associated with given file extension in the operating system

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/views/AbstractExtractableDesignView.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/views/AbstractExtractableDesignView.java
@@ -10,13 +10,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.views;
 
-import com.google.common.collect.Maps;
-
 import org.eclipse.wb.internal.core.editor.DesignComposite;
 import org.eclipse.wb.internal.core.editor.DesignComposite.IExtractableControl;
 
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -37,6 +33,7 @@ import org.eclipse.ui.part.PageBook;
 import org.eclipse.ui.part.PageBookView;
 import org.eclipse.ui.part.ViewPart;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -63,9 +60,7 @@ public abstract class AbstractExtractableDesignView extends PageBookView {
     hookIntoWorkbench();
     // simulate activation for all opened editors,
     // because it is possible that more than one of them are visible
-    parent.getDisplay().asyncExec(new Runnable() {
-      @Override
-      public void run() {
+    parent.getDisplay().asyncExec(() -> {
         IWorkbenchPage activePage = getSite().getWorkbenchWindow().getActivePage();
         IWorkbenchPart activePart = activePage.getActivePart();
         // show pages for all editors
@@ -78,8 +73,7 @@ public abstract class AbstractExtractableDesignView extends PageBookView {
         }
         // show page for original active part
         partActivated(activePart);
-      }
-    });
+      });
   }
 
   /**
@@ -105,14 +99,11 @@ public abstract class AbstractExtractableDesignView extends PageBookView {
       public void partHidden(IWorkbenchPartReference partRef) {
         // some "part" become hidden, if this means that "editor" maximized, do restore;
         // do in async, because editor state updated after "partHidden" event
-        Display.getCurrent().asyncExec(new Runnable() {
-          @Override
-          public void run() {
+        Display.getCurrent().asyncExec(() -> {
             if (isEditorMaximized()) {
               doRestore();
             }
-          }
-        });
+          });
       }
 
       @Override
@@ -165,12 +156,7 @@ public abstract class AbstractExtractableDesignView extends PageBookView {
     };
     page.addPartListener(partListener);
     // remove perspective listener on dispose
-    getPageBook().addDisposeListener(new DisposeListener() {
-      @Override
-      public void widgetDisposed(DisposeEvent e) {
-        page.removePartListener(partListener);
-      }
-    });
+    getPageBook().addDisposeListener(e -> page.removePartListener(partListener));
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -201,7 +187,7 @@ public abstract class AbstractExtractableDesignView extends PageBookView {
   // PageBookView
   //
   ////////////////////////////////////////////////////////////////////////////
-  private final Map<IWorkbenchPart, IExtractableControl> m_extractableControls = Maps.newHashMap();
+  private final Map<IWorkbenchPart, IExtractableControl> m_extractableControls = new HashMap<>();
 
   @Override
   protected IPage createDefaultPage(PageBook book) {


### PR DESCRIPTION
Guavas Maps.newHashMap(); is just wrapper around new HashMap<>(); so
letts use this directly. This will slightly reduce the complexity as we
have one library call less.