### PR TITLE
"lastgoodbuild" update site misses bundles from Maven Central

### DIFF
--- a/org.eclipse.wb.core.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.feature_feature/feature.xml
@@ -53,6 +53,18 @@
          version="0.0.0"/>
 
    <plugin
+         id="com.google.guava"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="com.google.guava.failureaccess"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
          id="org.eclipse.wb.os.linux"
          os="linux"
          ws="gtk"

--- a/org.eclipse.wb.core.java.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.java.feature_feature/feature.xml
@@ -35,4 +35,22 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.apache.commons.commons-beanutils"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.digester"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.logging"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
 </feature>


### PR DESCRIPTION
**Problem:**
The [bundles that have the `type="Maven"` in the target platform](https://github.com/eclipse/windowbuilder/blob/fe1008e1dd67634a735efa7feef389fdcb2c1bfb/target-platform/wb.target#L12-L61) are currently missing in the [_lastgoodbuild_ update site](https://download.eclipse.org/windowbuilder/lastgoodbuild/) since they are not contained in any feature. This prevents an installation of WindowBuilder from the _lastgoodbuild_ update site.

**Solution:**
Add those bundles to the corresponding features.