### PR TITLE
Improve the target platform setup for better reuse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
 	<module>org.eclipse.wb.swing.feature_feature</module>
 	<module>org.eclipse.wb.swt.feature_feature</module>
 	<module>org.eclipse.wb.xwt.feature_feature</module>
+	<module>target-platform</module>
     </modules>
 
 </project> 

--- a/setups/WindowBuilder.setup
+++ b/setups/WindowBuilder.setup
@@ -132,6 +132,7 @@
               url="https://download.eclipse.org/cbi/updates/license"/>
         </repositoryList>
       </targlet>
+      <composedTarget>wb-mvn</composedTarget>
     </setupTask>
     <setupTask
         xsi:type="setup.workingsets:WorkingSetTask"

--- a/target-platform/mvn/wb-mvn.target
+++ b/target-platform/mvn/wb-mvn.target
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="wb-mvn">
+	<locations>
+		<location includeDependencyDepth="none" includeDependencyScopes="provided,runtime,test,system,import" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+					<version>31.1-jre</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+		<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>com.google.guava</groupId>
+					<artifactId>failureaccess</artifactId>
+					<version>1.0.1</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+			<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils</artifactId>
+					<version>1.9.4</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-digester3</artifactId>
+					<version>3.2</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+		<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+					<version>1.2</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
+	</locations>
+</target>

--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -9,55 +9,6 @@
 			<unit id="org.eclipse.wst.sse.ui" version="0.0.0"/>
 			<unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 		</location>
-		<location includeDependencyDepth="none" includeDependencyScopes="provided,runtime,test,system,import" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-					<version>31.1-jre</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
-		</location>
-		<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>com.google.guava</groupId>
-					<artifactId>failureaccess</artifactId>
-					<version>1.0.1</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
-		</location>
-			<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>commons-beanutils</groupId>
-					<artifactId>commons-beanutils</artifactId>
-					<version>1.9.4</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
-		</location>
-		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-digester3</artifactId>
-					<version>3.2</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
-		</location>
-		<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
-			<dependencies>
-				<dependency>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-					<version>1.2</version>
-					<type>jar</type>
-				</dependency>
-			</dependencies>
-		</location>
+		<location type="Target" uri="file:${project_loc:/target-platform}/mvn/wb-mvn.target"/>
 	</locations>
 </target>


### PR DESCRIPTION
Split out from wb.target, the Maven locations into a separate a
wb-maven.target that can be included/composed into both the wb.target
and in the targlet task of the WindowBuilder.setup.

Tycho 2.7.3 can consume such a composed *.target and the targlet setup
avoids duplicating the resolution of the non-Maven content to the target
platform.