### PR TITLE
wb.jdt.fragment BREE has been updated to Java 11

### DIFF
--- a/org.eclipse.wb.jdt.fragment/.classpath
+++ b/org.eclipse.wb.jdt.fragment/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/org.eclipse.wb.jdt.fragment/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.wb.jdt.fragment/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=48
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=80

--- a/org.eclipse.wb.jdt.fragment/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.jdt.fragment/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Vendor: %providerName
 Bundle-Version: 1.9.1.qualifier
 Bundle-Localization: fragment
 Fragment-Host: org.eclipse.jdt.core;bundle-version="3.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .
 Export-Package: org.eclipse.jdt.core.dom
 Automatic-Module-Name: org.eclipse.wb.jdt.fragment


### PR DESCRIPTION
As jdt.core is also on Java 11 we should adjust the fragment to use the
same (actually I don't think the BREE of the fragment is relevant, but
why challenge the setup and ask for undiscovered bugs).