### PR TITLE
Running SwtTests as first test suite

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/WindowBuilderTests.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/WindowBuilderTests.java
@@ -29,11 +29,11 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+	SwtTests.class,
     CommonTests.class,
     CoreTests.class,
     EditorTests.class,
     SwingTests.class,
-    SwtTests.class,
     RcpTests.class
 // not yet ready to run, need work to run successfully
 // XmlTests.class,


### PR DESCRIPTION
SwtTests show frequently random error failures, which are hard to
reproduce. By moving the test suite to the top we should see these
errors earlier, it might also reduce the side-effects of other tests,
currently the test suite run without errors on my local machine.