### PR TITLE
Ignore new polyglot.wb.target file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ target/
 .polyglot.feature.xml
 .polyglot.META-INF
 .tycho-consumer-pom.xml
+.polyglot*target
+


### PR DESCRIPTION
https://github.com/eclipse/windowbuilder/pull/282 added target-plaform as module, so we should ignore the generated file for git.