### PR TITLE
Ensure that the direct-from-maven dependences are PGP signed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,17 @@
 				   <defaultP2Metadata>false</defaultP2Metadata>
 				 </configuration>
 			   </plugin>
+			   <plugin>
+				 <groupId>org.eclipse.tycho</groupId>
+				 <artifactId>tycho-gpg-plugin</artifactId>
+				 <executions>
+				   <execution>
+					 <goals>
+					   <goal>sign-p2-artifacts</goal>
+					 </goals>
+				   </execution>
+				 </executions>
+			   </plugin>
 			 </plugins>
 		   </build>
 		   <pluginRepositories>


### PR DESCRIPTION
The tycho-gpg-plugin is used for that purpose.

https://github.com/eclipse/windowbuilder/issues/302