### PR TITLE
Ensures that org.eclipse.wb.swt.ResourceManager is available for the

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/resource/ResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/resource/ResourceManagerTest.java
@@ -10,8 +10,10 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.rcp.resource;
 
+import org.eclipse.wb.internal.core.model.description.ToolkitDescriptionJava;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+import org.eclipse.wb.internal.rcp.RcpToolkitDescription;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
 import org.eclipse.wb.internal.swt.utils.ManagerUtils;
@@ -52,15 +54,10 @@ public class ResourceManagerTest extends RcpModelTest {
     ((List<?>) ReflectionUtils.getFieldObject(this, "m_createdResources")).clear();
     waitForAutoBuild();
     PdeProjectConversionUtils.convertToPDE(m_testProject.getProject(), null, "testplugin.Activator");
-  }
 
-  ////////////////////////////////////////////////////////////////////////////
-  //
-  // Exit zone :-) XXX
-  //
-  ////////////////////////////////////////////////////////////////////////////
-  public void _test_exit() throws Exception {
-    System.exit(0);
+	// ensure org.eclipse.wb.swt.ResourceManager is available in the created project
+	ToolkitDescriptionJava toolKit = RcpToolkitDescription.INSTANCE;
+	ManagerUtils.ensure_ResourceManager(m_javaProject, toolKit);
   }
 
   ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
ResourceManagerTest

The ResourceManagerTest assumed that the first test in the file is
executed as a first test as this would ensure that the ResourceManager
class is available in the test.

The waitForAutoBuild() checked for such cases but it was hard to see. So
by commenting assertEquals() at the end of this method out and by adding
he following code after the waitForAutoBuild() call in the test I could
use the runtime IDE after the failing situation to see what actually is
the case in Eclipse.

	Display.getDefault().syncExec(() ->

	{
		while (true) {
			Display.getDefault().readAndDispatch();
		}

	});

This way it was easy to see that the corresponding file was not present
the generated test code.