### PR TITLE
[1/2] Databinding binds to deprecated classes (Properties Classes) #323 

### DIFF
--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/CreatorManager.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/CreatorManager.java
@@ -299,28 +299,28 @@ final class CreatorManager {
         "org.eclipse.core.databinding.beans.BeansObservables.observeValue(org.eclipse.core.databinding.observable.Realm,java.lang.Object,java.lang.String)",
         "org.eclipse.core.databinding.beans.PojoObservables.observeValue(org.eclipse.core.databinding.observable.Realm,java.lang.Object,java.lang.String)");
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.value(java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.value(java.lang.String)",
         new LocalModelCreator(0, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.value(java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.value(java.lang.String,java.lang.Class)",
         new LocalModelCreator(0, 1, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.value(java.lang.Class,java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.value(java.lang.Class,java.lang.String)",
         new LocalModelCreator(1, -1, 0, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.value(java.lang.Class,java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.value(java.lang.Class,java.lang.String,java.lang.Class)",
         new LocalModelCreator(1, 2, 0, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.value(java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.value(java.lang.String)",
         new LocalModelCreator(0, true, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.value(java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.value(java.lang.String,java.lang.Class)",
         new LocalModelCreator(0, 1, true, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.value(java.lang.Class,java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.value(java.lang.Class,java.lang.String)",
         new LocalModelCreator(1, -1, 0, true, VALUE_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.value(java.lang.Class,java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.value(java.lang.Class,java.lang.String,java.lang.Class)",
         new LocalModelCreator(1, 2, 0, true, VALUE_PROPERTY_CREATOR));
     //
     methodCreator(
@@ -340,28 +340,28 @@ final class CreatorManager {
         "org.eclipse.core.databinding.beans.BeansObservables.observeList(org.eclipse.core.databinding.observable.Realm,java.lang.Object,java.lang.String,java.lang.Class)",
         "org.eclipse.core.databinding.beans.PojoObservables.observeList(org.eclipse.core.databinding.observable.Realm,java.lang.Object,java.lang.String,java.lang.Class)");
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.list(java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.list(java.lang.String)",
         new LocalModelCreator(0, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.list(java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.list(java.lang.String,java.lang.Class)",
         new LocalModelCreator(0, 1, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.list(java.lang.Class,java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.list(java.lang.Class,java.lang.String)",
         new LocalModelCreator(1, -1, 0, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.list(java.lang.Class,java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.list(java.lang.Class,java.lang.String,java.lang.Class)",
         new LocalModelCreator(1, 2, 0, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.list(java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.list(java.lang.String)",
         new LocalModelCreator(0, true, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.list(java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.list(java.lang.String,java.lang.Class)",
         new LocalModelCreator(0, 1, true, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.list(java.lang.Class,java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.list(java.lang.Class,java.lang.String)",
         new LocalModelCreator(1, -1, 0, true, LIST_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.list(java.lang.Class,java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.list(java.lang.Class,java.lang.String,java.lang.Class)",
         new LocalModelCreator(1, 2, 0, true, LIST_PROPERTY_CREATOR));
     //
     methodCreator(
@@ -381,28 +381,28 @@ final class CreatorManager {
         "org.eclipse.core.databinding.beans.BeansObservables.observeSet(org.eclipse.core.databinding.observable.Realm,java.lang.Object,java.lang.String,java.lang.Class)",
         "org.eclipse.core.databinding.beans.PojoObservables.observeSet(org.eclipse.core.databinding.observable.Realm,java.lang.Object,java.lang.String,java.lang.Class)");
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.set(java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.set(java.lang.String)",
         new LocalModelCreator(0, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.set(java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.set(java.lang.String,java.lang.Class)",
         new LocalModelCreator(0, 1, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.set(java.lang.Class,java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.set(java.lang.Class,java.lang.String)",
         new LocalModelCreator(1, -1, 0, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.BeanProperties.set(java.lang.Class,java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.BeanProperties.set(java.lang.Class,java.lang.String,java.lang.Class)",
         new LocalModelCreator(1, 2, 0, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.set(java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.set(java.lang.String)",
         new LocalModelCreator(0, true, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.set(java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.set(java.lang.String,java.lang.Class)",
         new LocalModelCreator(0, 1, true, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.set(java.lang.Class,java.lang.String)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.set(java.lang.Class,java.lang.String)",
         new LocalModelCreator(1, -1, 0, true, SET_PROPERTY_CREATOR));
     METHOD_CREATORS.put(
-        "org.eclipse.core.databinding.beans.PojoProperties.set(java.lang.Class,java.lang.String,java.lang.Class)",
+        "org.eclipse.core.databinding.beans.typed.PojoProperties.set(java.lang.Class,java.lang.String,java.lang.Class)",
         new LocalModelCreator(1, 2, 0, true, SET_PROPERTY_CREATOR));
     //
     METHOD_CREATORS.put(

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ListPropertyCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ListPropertyCodeSupport.java
@@ -82,8 +82,8 @@ public class ListPropertyCodeSupport extends BeanPropertiesCodeSupport {
     //
     String sourceCode =
         observable.isPojoBindable()
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     sourceCode += ".list(" + observable.getBindableProperty().getReference() + ")";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
@@ -111,8 +111,8 @@ public class ListPropertyCodeSupport extends BeanPropertiesCodeSupport {
       CodeGenerationSupport generationSupport) throws Exception {
     String sourceCode =
         m_parserIsPojo
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     sourceCode +=
         ".list("
             + detailObservable.getDetailPropertyReference()

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ListPropertyDetailCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ListPropertyDetailCodeSupport.java
@@ -38,8 +38,8 @@ public class ListPropertyDetailCodeSupport extends BeanObservableDetailCodeSuppo
     //
     String sourceCode =
         observable.isPojoBindable0()
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     String beanClassCode =
         observable.getDetailBeanClass() == null
             ? ""

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/SetPropertyCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/SetPropertyCodeSupport.java
@@ -82,8 +82,8 @@ public class SetPropertyCodeSupport extends BeanPropertiesCodeSupport {
     //
     String sourceCode =
         observable.isPojoBindable()
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     sourceCode += ".set(" + observable.getBindableProperty().getReference() + ")";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
@@ -111,8 +111,8 @@ public class SetPropertyCodeSupport extends BeanPropertiesCodeSupport {
       CodeGenerationSupport generationSupport) throws Exception {
     String sourceCode =
         m_parserIsPojo
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     sourceCode +=
         ".set("
             + detailObservable.getDetailPropertyReference()

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/SetPropertyDetailCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/SetPropertyDetailCodeSupport.java
@@ -37,8 +37,8 @@ public class SetPropertyDetailCodeSupport extends BeanObservableDetailCodeSuppor
       ObservableInfo masterObservable) throws Exception {
     String sourceCode =
         observable.isPojoBindable0()
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     String beanClassCode =
         observable.getDetailBeanClass() == null
             ? ""

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ValuePropertyCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ValuePropertyCodeSupport.java
@@ -80,8 +80,8 @@ public class ValuePropertyCodeSupport extends BeanPropertiesCodeSupport {
       if (generationSupport.addModel(this)) {
         String sourceCode =
             m_parserIsPojo
-                ? "org.eclipse.core.databinding.beans.PojoProperties"
-                : "org.eclipse.core.databinding.beans.BeanProperties";
+                ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+                : "org.eclipse.core.databinding.beans.typed.BeanProperties";
         lines.add("org.eclipse.core.databinding.beans.IBeanValueProperty "
             + getVariableIdentifier()
             + " = "
@@ -102,8 +102,8 @@ public class ValuePropertyCodeSupport extends BeanPropertiesCodeSupport {
     //
     String sourceCode =
         observable.isPojoBindable()
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     sourceCode += ".value(" + observable.getBindableProperty().getReference() + ")";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
@@ -133,8 +133,8 @@ public class ValuePropertyCodeSupport extends BeanPropertiesCodeSupport {
       CodeGenerationSupport generationSupport) throws Exception {
     String sourceCode =
         m_parserIsPojo
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     sourceCode +=
         ".value("
             + detailObservable.getDetailPropertyReference()

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ValuePropertyDetailCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/observables/properties/ValuePropertyDetailCodeSupport.java
@@ -37,8 +37,8 @@ public class ValuePropertyDetailCodeSupport extends BeanObservableDetailCodeSupp
       ObservableInfo masterObservable) throws Exception {
     String sourceCode =
         observable.isPojoBindable0()
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     String beanClassCode =
         observable.getDetailBeanClass() == null
             ? ""

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/WidgetsObserveTypeContainer.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/WidgetsObserveTypeContainer.java
@@ -153,13 +153,13 @@ public final class WidgetsObserveTypeContainer extends ObserveTypeContainer {
       "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text(int)",
       "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text(int[])"};
   private static final String SINGLE_SELECTION_VIEWER_PROPERTY =
-      "org.eclipse.jface.databinding.viewers.ViewerProperties.singleSelection()";
+      "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.singleSelection()";
   private static final String MULTI_SELECTION_VIEWER_PROPERTY =
-      "org.eclipse.jface.databinding.viewers.ViewerProperties.multipleSelection()";
+      "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.multipleSelection()";
   private static final String CHECKED_ELEMENTS_VIEWER_PROPERTY =
-      "org.eclipse.jface.databinding.viewers.ViewerProperties.checkedElements(java.lang.Object)";
+      "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.checkedElements(java.lang.Object)";
   private static final String FILTERS_ELEMENTS_VIEWER_PROPERTY =
-      "org.eclipse.jface.databinding.viewers.ViewerProperties.filters()";
+      "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.filters()";
   private List<WidgetBindableInfo> m_observables = Collections.emptyList();
   private DatabindingsProvider m_provider;
 

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/WidgetsObserveTypeContainer.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/WidgetsObserveTypeContainer.java
@@ -129,29 +129,29 @@ public final class WidgetsObserveTypeContainer extends ObserveTypeContainer {
   private static final String OBSERVABLE_VIEWER_FILTERS_METHOD =
       "org.eclipse.jface.databinding.viewers.ViewersObservables.observeFilters(org.eclipse.jface.viewers.StructuredViewer)";
   private static final String[] WIDGET_PROPERTIES_METHODS = {
-      "org.eclipse.jface.databinding.swt.WidgetProperties.background()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.bounds()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.editable()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.enabled()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.focused()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.font()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.foreground()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.image()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.location()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.maximum()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.message()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.minimum()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.selection()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.singleSelectionIndex()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.size()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.tooltipText()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.visible()"};
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.background()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.bounds()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.editable()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.enabled()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.focused()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.font()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.foreground()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.image()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.location()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.maximum()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.message()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.minimum()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.selection()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.singleSelectionIndex()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.size()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.tooltipText()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.visible()"};
   private static final String ITEMS_WIDGET_PROPERTY =
-      "org.eclipse.jface.databinding.swt.WidgetProperties.items()";
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.items()";
   private static final String[] TEXT_WIDGET_PROPERTIES = {
-      "org.eclipse.jface.databinding.swt.WidgetProperties.text()",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.text(int)",
-      "org.eclipse.jface.databinding.swt.WidgetProperties.text(int[])"};
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text()",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text(int)",
+      "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text(int[])"};
   private static final String SINGLE_SELECTION_VIEWER_PROPERTY =
       "org.eclipse.jface.databinding.viewers.ViewerProperties.singleSelection()";
   private static final String MULTI_SELECTION_VIEWER_PROPERTY =

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/CellEditorValuePropertyCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/CellEditorValuePropertyCodeSupport.java
@@ -106,7 +106,7 @@ public final class CellEditorValuePropertyCodeSupport extends ObservableCodeSupp
       // simple property
       lines.add("org.eclipse.core.databinding.property.value.IValueProperty "
           + getVariableIdentifier()
-          + " = org.eclipse.core.databinding.beans.BeanProperties.value("
+          + " = org.eclipse.core.databinding.beans.typed.BeanProperties.value("
           + getParsePropertyReference()
           + ");");
     } else {

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/ViewerCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/ViewerCodeSupport.java
@@ -50,8 +50,8 @@ public class ViewerCodeSupport extends CodeSupport {
     String[] properties = m_binding.getLabelProvider().getMapsObservable().getProperties();
     String propertiesSourceCode =
         ObservableInfo.isPojoBean(elementType)
-            ? "org.eclipse.core.databinding.beans.PojoProperties"
-            : "org.eclipse.core.databinding.beans.BeanProperties";
+            ? "org.eclipse.core.databinding.beans.typed.PojoProperties"
+            : "org.eclipse.core.databinding.beans.typed.BeanProperties";
     //
     lines.add("org.eclipse.jface.databinding.viewers.ViewerSupport.bind("
         + m_binding.getViewer().getReference()

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/ViewerInputParser.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/input/ViewerInputParser.java
@@ -62,9 +62,9 @@ public final class ViewerInputParser implements ISubParser {
   private static final String VIEWER_SUPPORT_SET_SIGNATURE =
       "org.eclipse.jface.databinding.viewers.ViewerSupport.bind(org.eclipse.jface.viewers.StructuredViewer,org.eclipse.core.databinding.observable.set.IObservableSet,org.eclipse.core.databinding.property.value.IValueProperty[])";
   private static final String BEAN_PROPERTIES_VALUES =
-      "org.eclipse.core.databinding.beans.BeanProperties.values(java.lang.Class,java.lang.String[])";
+      "org.eclipse.core.databinding.beans.typed.BeanProperties.values(java.lang.Class,java.lang.String[])";
   private static final String POJO_PROPERTIES_VALUES =
-      "org.eclipse.core.databinding.beans.PojoProperties.values(java.lang.Class,java.lang.String[])";
+      "org.eclipse.core.databinding.beans.typed.PojoProperties.values(java.lang.Class,java.lang.String[])";
   private static final String OBSERVABLE_VALUE_EDITING_SUPPORT =
       "org.eclipse.jface.databinding.viewers.ObservableValueEditingSupport.create(org.eclipse.jface.viewers.ColumnViewer,org.eclipse.core.databinding.DataBindingContext,org.eclipse.jface.viewers.CellEditor,org.eclipse.core.databinding.property.value.IValueProperty,org.eclipse.core.databinding.property.value.IValueProperty)";
   private static final String VIEWER_COLUMN_SET_EDITING_SUPPORT =

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertyCheckedElementsCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertyCheckedElementsCodeSupport.java
@@ -70,7 +70,7 @@ public class ViewerPropertyCheckedElementsCodeSupport extends ViewerObservableCo
     super.addSourceCode(observable, lines, generationSupport);
     CheckedElementsObservableInfo checkedObservable = (CheckedElementsObservableInfo) observable;
     String sourceCode =
-        "org.eclipse.jface.databinding.viewers.ViewerProperties.checkedElements("
+        "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.checkedElements("
             + CoreUtils.getClassName(checkedObservable.getElementType())
             + ".class)";
     if (getVariableIdentifier() != null) {

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertyFiltersCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertyFiltersCodeSupport.java
@@ -58,7 +58,7 @@ public class ViewerPropertyFiltersCodeSupport extends ViewerObservableCodeSuppor
       List<String> lines,
       CodeGenerationSupport generationSupport) throws Exception {
     super.addSourceCode(observable, lines, generationSupport);
-    String sourceCode = "org.eclipse.jface.databinding.viewers.ViewerProperties.filters()";
+    String sourceCode = "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.filters()";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
         lines.add("org.eclipse.jface.databinding.viewers.IViewerSetProperty "

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertyMultiSelectionCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertyMultiSelectionCodeSupport.java
@@ -59,7 +59,7 @@ public class ViewerPropertyMultiSelectionCodeSupport extends ViewerObservableCod
       CodeGenerationSupport generationSupport) throws Exception {
     super.addSourceCode(observable, lines, generationSupport);
     String sourceCode =
-        "org.eclipse.jface.databinding.viewers.ViewerProperties.multipleSelection()";
+        "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.multipleSelection()";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
         lines.add("org.eclipse.jface.databinding.viewers.IViewerListProperty "

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertySingleSelectionCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/ViewerPropertySingleSelectionCodeSupport.java
@@ -118,7 +118,7 @@ public class ViewerPropertySingleSelectionCodeSupport extends ViewerObservableCo
       List<String> lines,
       CodeGenerationSupport generationSupport) throws Exception {
     super.addSourceCode(observable, lines, generationSupport);
-    String sourceCode = "org.eclipse.jface.databinding.viewers.ViewerProperties.singleSelection()";
+    String sourceCode = "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.singleSelection()";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
         lines.add("org.eclipse.jface.databinding.viewers.IViewerValueProperty "
@@ -155,7 +155,7 @@ public class ViewerPropertySingleSelectionCodeSupport extends ViewerObservableCo
 
   public String getMasterSourceCode(List<String> lines, CodeGenerationSupport generationSupport)
       throws Exception {
-    String sourceCode = "org.eclipse.jface.databinding.viewers.ViewerProperties.singleSelection()";
+    String sourceCode = "org.eclipse.jface.databinding.viewers.typed.ViewerProperties.singleSelection()";
     if (getVariableIdentifier() == null) {
       return sourceCode;
     }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/WidgetPropertiesCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/WidgetPropertiesCodeSupport.java
@@ -107,7 +107,7 @@ public class WidgetPropertiesCodeSupport extends AbstractWidgetPropertiesCodeSup
    * @return the source code for create this observable.
    */
   protected String getSourceCode(ObservableInfo observable) throws Exception {
-    return "org.eclipse.jface.databinding.swt.WidgetProperties."
+    return "org.eclipse.jface.databinding.swt.typed.WidgetProperties."
         + SwtProperties.SWT_OBSERVABLES_TO_WIDGET_PROPERTIES.get(observable.getBindableProperty().getReference())
         + "()";
   }
@@ -116,7 +116,7 @@ public class WidgetPropertiesCodeSupport extends AbstractWidgetPropertiesCodeSup
    * @return the source code.
    */
   public String getSourceCode() throws Exception {
-    return "org.eclipse.jface.databinding.swt.WidgetProperties."
+    return "org.eclipse.jface.databinding.swt.typed.WidgetProperties."
         + SwtProperties.SWT_OBSERVABLES_TO_WIDGET_PROPERTIES.get(getPropertyReference())
         + "()";
   }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/WidgetPropertyItemsCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/WidgetPropertyItemsCodeSupport.java
@@ -65,7 +65,7 @@ public class WidgetPropertyItemsCodeSupport extends AbstractWidgetPropertiesCode
           "ObserveWidget"));
     }
     // add code
-    String code = " = org.eclipse.jface.databinding.swt.WidgetProperties.items()";
+    String code = " = org.eclipse.jface.databinding.swt.typed.WidgetProperties.items()";
     if (getVariableIdentifier() != null) {
       if (generationSupport.addModel(this)) {
         lines.add("org.eclipse.jface.databinding.viewers.IViewerValueProperty "

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/WidgetPropertyTextCodeSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/widgets/observables/properties/WidgetPropertyTextCodeSupport.java
@@ -71,7 +71,7 @@ public class WidgetPropertyTextCodeSupport extends WidgetPropertiesCodeSupport {
     if (updateEvents.size() == 0) {
       return super.getSourceCode(observable);
     }
-    return "org.eclipse.jface.databinding.swt.WidgetProperties.text("
+    return "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text("
         + getEventsSourceCode(updateEvents)
         + ")";
   }
@@ -82,7 +82,7 @@ public class WidgetPropertyTextCodeSupport extends WidgetPropertiesCodeSupport {
       return super.getSourceCode();
     }
     List<String> updateEvents = TextSwtObservableInfo.getEventsSources(m_parseEvents);
-    return "org.eclipse.jface.databinding.swt.WidgetProperties.text("
+    return "org.eclipse.jface.databinding.swt.typed.WidgetProperties.text("
         + getEventsSourceCode(updateEvents)
         + ")";
   }


### PR DESCRIPTION
This PR updates the Properties class references to the new locations. It only implements a partial solution of the deprecated class databinding. For the properties files the replacement is quite simple, as the only change (wrt to windowbuilder) is the package renaming.


- [X] org.eclipse.core.databinding.beans.BeanProperties -> org.eclipse.core.databinding.beans.typed.BeanProperties
- [X] org.eclipse.core.databinding.beans.PojoProperties -> org.eclipse.core.databinding.beans.typed.PojoProperties
- [X] org.eclipse.jface.databinding.swt.WidgetProperties -> org.eclipse.jface.databinding.swt.typed.WidgetProperties
- [X] org.eclipse.jface.databinding.viewers.ViewerProperties -> org.eclipse.jface.databinding.viewers.typed.ViewerProperties

**Bound for separate PR** as the implementation substantially differs, and a drop-in-replacement is not easily possible:

- [ ] org.eclipse.core.databinding.beans.BeansObservables.observe* -> reimplement required functions in `org.eclipse.core.databinding.beans.typed.BeanProperties`
- [ ] org.eclipse.jface.databinding.swt.SWTObservables.observe* ->  reimplement required functions in `org.eclipse.jface.databinding.swt.typed.WidgetProperties`
- [ ] org.eclipse.core.databinding.beans.PojoObservables? -> reimplement required functions in ` org.eclipse.core.databinding.beans.typed.PojoProperties`
- [ ] org.eclipse.jface.databinding.viewers.ViewersObservables -> reimplement required functions in `org.eclipse.jface.databinding.viewers.typed.ViewerProperties`

General info
see https://bugs.eclipse.org/bugs/show_bug.cgi?id=546820
see https://git.eclipse.org/c/platform/eclipse.platform.ui.git/commit/?id=4f25fbf41f9411ded14d3cec0e951e7bcaf51319