### PR TITLE
Upload test results, even on test failures.

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
        run: >- 
-        mvn -V -B clean verify
+        mvn -V -B -D maven.test.failure.ignore=true clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Currently, the build job is aborted when at least one test has failed. As a result, none of the test results are uploaded to GitHub, and the developer has to either manually dig through the build log or retest them manually. With this change, the Maven build will ignore test failures and the pipeline instead fails after evaluating the test results.