### PR TITLE
The artifact name for the test results should be unique.

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: test-results-${{ matrix.config.native }}-java${{ matrix.java }}
+        name: test-results-${{ matrix.os }}-java${{ matrix.java }}
         if-no-files-found: error
         path: |
           ${{ github.workspace }}/**/target/surefire-reports/*.xml


### PR DESCRIPTION
The property 'matrix.config.native' is not set on the build nodes. Therefore, the artifact name is e.g. 'test-results--java11' for the Java 11 builds, for both the Windows and Linux build. This means the that the test results that are uploaded first are overwritten by the ones that are uploaded last, meaning we only upload half the test results and miss out on potential test failures!

By using 'matrix.os', the same property used in the job matrix, we can ensure that it exists and - in combination with the Java version - is unique.