### PR TITLE
Fail the verification build if we have test errors

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -29,9 +29,10 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
        run: >- 
-        mvn -V -B -D maven.test.failure.ignore=true clean verify
+        mvn -V -B -fae clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: test-results-${{ matrix.config.native }}-java${{ matrix.java }}
         if-no-files-found: error


### PR DESCRIPTION
The setup introduced with 3b9a81b9679e0583045ad9e19cfe802fd9dd8588 results in the false impression that everything works fine, even with our currently lots of unit test errors.

I suggest we have the verification build again if we have test errors so that we have to fix or disable the failing tests and make it easier for use to avoid changes which result in new failing test.