### PR TITLE
Update xvfb-action to a version which is using Node.js v16

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -26,7 +26,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Build with Maven
-      uses: GabrielBB/xvfb-action@v1
+      uses: coactions/setup-xvfb@v1
       with:
        run: >- 
         mvn -V -B -D maven.test.failure.ignore=true clean verify


### PR DESCRIPTION
The xvfg-action by GabrielBB is no longer maintained as has been replaced by setub-xvfb. Furthermore, the old action is still using an old version of Node.js, which is announced to be deprecated by the summer of this year.

From the GitHub documentation:

Node 12 has been out of support since April 2022, as a result we have started the deprecation process of Node 12 for GitHub Actions. We plan to migrate all actions to run on Node16 by Summer 2023. We will monitor the progress of the migration and listen to the community for how things are going before we define a final date.

To raise awareness of the upcoming change, we are adding a warning into workflows which contain Actions running on Node 12. This will come into effect starting on September 27th.