### PR TITLE
Update to Tycho 3.0.4

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [ 11, 17 ]
+        java: [ 17 ]
     runs-on: ${{ matrix.os }}   
     name: OS ${{ matrix.os }} Java ${{ matrix.java }} compile
     steps:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.3</version>
+    <version>3.0.4</version>
   </extension>
 </extensions> 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	
 	<properties>
-		<tycho.version>2.7.3</tycho.version>
+		<tycho.version>3.0.4</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>  
 		<eclipse-jarsigner-version>1.3.2</eclipse-jarsigner-version>
 	  </properties>


### PR DESCRIPTION
As Tycho requires Java 17, only use Java 17 for verification, as we anyhow plan to move WB to Java 17