### PR TITLE
Fail the verification build if we have test errors

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         java: [ 11, 17 ]
@@ -29,9 +30,10 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
        run: >- 
-        mvn -V -B -D maven.test.failure.ignore=true clean verify
+        mvn -V -B -fae clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: test-results-${{ matrix.config.native }}-java${{ matrix.java }}
         if-no-files-found: error

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
   unit-test-results:
     name: Unit Test Results
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
       - name: Download and Extract Artifacts


### PR DESCRIPTION
The setup introduced with 3b9a81b
results in the false impression that everything works fine, even with our currently lots of unit test errors.

I suggest we have the verification build again if we have test errors so that we have to fix or disable the failing tests and make it easier for use to avoid changes which result in new failing test.

Test results are uploaded, regardless of test failures, so that they can be accessed by the "Publish Test Results" action. The fast-fail has been disabled, to ensure that test failures in one matrix job doesn't cancel the remaining, still running jobs. Lastly, the "Publish Test Results" action has been adapted to not only publish the results on success, but also on failure.