### PR TITLE
Remove reflective access to x & y coordinates of ExpandItem widget.

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ExpandItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/ExpandItemInfo.java
@@ -142,8 +142,6 @@ public final class ExpandItemInfo extends ItemInfo {
     {
       Object object = getObject();
       int headerHeight = (Integer) ReflectionUtils.invokeMethod2(object, "getHeaderHeight");
-      int x = ReflectionUtils.getFieldInt(object, "x");
-      int y = ReflectionUtils.getFieldInt(object, "y");
       int width = ReflectionUtils.getFieldInt(object, "width");
       int height = ReflectionUtils.getFieldInt(object, "height");
       if (isExpanded()) {
@@ -151,7 +149,9 @@ public final class ExpandItemInfo extends ItemInfo {
       } else {
         height = headerHeight;
       }
-      setModelBounds(new Rectangle(x, y, width, height));
+      // x & y fields may not exist on every platform
+      // but as far as I can tell, they are always initialized with 0
+      setModelBounds(new Rectangle(0, 0, width, height));
     }
     super.refresh_fetch();
   }


### PR DESCRIPTION
Those fields only exist in the win32 widgets, but not in the gtk widgets, leading to a NoSuchFieldError if trying to be used on Linux.

As far as I can tell, those coordinates are always set to 0, which are used instead, to determine the model bounds.