### PR TITLE
Fix invalid bounds of Swing components on Linux

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ComponentInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ComponentInfo.java
@@ -159,18 +159,6 @@ public class ComponentInfo extends AbstractComponentInfo {
         java.awt.Rectangle bounds = component.getBounds();
         // store model bounds
         model.setModelBounds(CoordinateUtils.get(bounds));
-        // convert location in parent "bounds" coordinates
-        if (model.getParent() instanceof AbstractComponentInfo) {
-          AbstractComponentInfo parentModel = (AbstractComponentInfo) model.getParent();
-          Object parentObject = parentModel.getComponentObject();
-          if (parentObject instanceof Component) {
-            Component parentComponent = (Component) parentObject;
-            java.awt.Point p_component = SwingUtils.getScreenLocation(component);
-            java.awt.Point p_parent = SwingUtils.getScreenLocation(parentComponent);
-            bounds.x = p_component.x - p_parent.x;
-            bounds.y = p_component.y - p_parent.y;
-          }
-        }
         // remember bounds
         model.setBounds(CoordinateUtils.get(bounds));
       }


### PR DESCRIPTION
Trying to fetch the screen location of the parent and child component sporadically results in broken coordinates. For example, (3855, 314) for the parent and (10030, 10029) for the child, even though (4350, 744) and (4525, 749) were expected. This leads to a new bound located somewhere outside of the design page.