### PR TITLE
Fix NPE in ComponentsPropertiesPageTest.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagLayoutGefTest.java
@@ -100,6 +100,8 @@ public class GridBagLayoutGefTest extends SwingGefTest {
             FigureCanvas control = viewer.getControl();
             Image image = OSSupport.get().makeShot(control);
             image.dispose();
+            // Shell is set to invisible on Linux, causing successive tests to fail...
+            control.getShell().setVisible(true);
           }
         });
       }


### PR DESCRIPTION
When executing the entire test suite, the GridBagLayoutGefTest is executed before the ComponentsPropertiesPageTest. One of the side-effects of this test is that the shell, in this case the entire IDE, is set to invisible, after calling OSSupport.makeShot().

If a successive test case now opens the design page, the property table is not initialized, leading to this error.