### PR TITLE
Stabilize IconPropertyEditorTest on Windows builds

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/IconPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/IconPropertyEditorTest.java
@@ -64,7 +64,7 @@ public class IconPropertyEditorTest extends SwingModelTest {
           "  }",
           "}"});
     } finally {
-      imageFile.delete(true, null);
+      forceDeleteFile(imageFile);
     }
   }
 
@@ -85,7 +85,7 @@ public class IconPropertyEditorTest extends SwingModelTest {
               "  }",
               "}"});
     } finally {
-      imageFile.delete(true, null);
+      forceDeleteFile(imageFile);
     }
   }
 


### PR DESCRIPTION
The test fails because the image, that was created as part of the test, can't be properly deleted. Most likely because of the wonky nature of the Windows file system...

Use forceDeleteFile instead, which should properly handle the CoreException.