### PR TITLE
[GTK] Ensure that layout is performed on all composites

### DIFF
--- a/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -146,7 +146,7 @@ public abstract class OSSupportLinux<H extends Number> extends OSSupport {
 
   @Override
   public void beginShot(Object controlObject) {
-    Shell shell = getShell(controlObject);
+    Shell shell = layoutShell(controlObject);
     // setup key title to be used by compiz WM (if enabled)
     changeTitle(shell);
     if (!isWorkaroundsDisabled()) {


### PR DESCRIPTION
In case the size of a widget or composite is determined by its layout, rather than a fixed size, the layout() function has to be explicitly called. Otherwise they are drawn with an empty size. This already happens on Windows and MacOS, but not on Linux.