### PR TITLE
Fix test failures in JDialog and JInternalFrame.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JDialogTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JDialogTest.java
@@ -64,8 +64,8 @@ public class JDialogTest extends SwingModelTest {
     }
     {
       Rectangle bounds = contentPane.getBounds();
-      assertThat(bounds.x).isGreaterThan(0);
-      assertThat(bounds.y).isGreaterThan(20);
+      assertThat(bounds.x).isEqualTo(0);
+      assertThat(bounds.y).isEqualTo(0);
       assertThat(bounds.width).isGreaterThan(420);
       assertThat(bounds.height).isGreaterThan(250);
     }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JInternalFrameTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JInternalFrameTest.java
@@ -63,8 +63,8 @@ public class JInternalFrameTest extends SwingModelTest {
     }
     {
       Rectangle bounds = contentPane.getBounds();
-      assertThat(bounds.x).isGreaterThan(0);
-      assertThat(bounds.y).isGreaterThan(20);
+      assertThat(bounds.x).isEqualTo(0);
+      assertThat(bounds.y).isEqualTo(0);
       assertThat(bounds.width).isGreaterThan(420);
       assertThat(bounds.height).isGreaterThan(250);
     }


### PR DESCRIPTION
Due to the changes done by #379, the composites are now always location at (0,0). On Windows, they were offset by a small margin. But not on Linux. This has been harmonized.