### PR TITLE
[GTK] Enable the redraw flag after screenshot has been taken

### DIFF
--- a/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -174,8 +174,8 @@ public abstract class OSSupportLinux<H extends Number> extends OSSupport {
   @Override
   public void endShot(Object controlObject) {
     // hide shell. The shell should be visible during all the period of fetching visual data.
+    super.endShot(controlObject);
     Shell shell = getShell(controlObject);
-    shell.setVisible(false);
     // restore title
     restoreTitle(shell);
     if (!isWorkaroundsDisabled()) {


### PR DESCRIPTION
When calling the beginShot() method, the redraw flag of the SWT widgets is set to false. In order to re-enable them after the shot has been taken, the endShot() method of the parent class has to be called as well. See fixZeroSizes_begin() and fixZeroSizes_end() for more details.

Amendment to #eba7cb5