### PR TITLE
Temporarily disable test cases related to empty bounds on Linux.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ExpandBarTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/ExpandBarTest.java
@@ -51,7 +51,8 @@ public class ExpandBarTest extends RcpModelTest {
   /**
    * {@link ExpandBar} with {@link ExpandItem}'s.
    */
-  public void test_parseItems() throws Exception {
+  // Disabled because of https://github.com/eclipse/windowbuilder/issues/389
+  public void DISABLE_test_parseItems() throws Exception {
     CompositeInfo shell =
         parseComposite(
             "public class Test extends Shell {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/TableGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/widgets/TableGefTest.java
@@ -35,7 +35,8 @@ public class TableGefTest extends RcpGefTest {
   // Canvas
   //
   ////////////////////////////////////////////////////////////////////////////
-  public void test_canvas_CREATE_column() throws Exception {
+  // Disabled because of https://github.com/eclipse/windowbuilder/issues/389
+  public void DISABLED_test_canvas_CREATE_column() throws Exception {
     openJavaInfo(
         "public class Test extends Table {",
         "  public Test(Composite parent, int style) {",
@@ -116,7 +117,8 @@ public class TableGefTest extends RcpGefTest {
         "}");
   }
 
-  public void test_canvas_RESIZE_column() throws Exception {
+  // Disabled because of https://github.com/eclipse/windowbuilder/issues/389
+  public void DISABLE_test_canvas_RESIZE_column() throws Exception {
     openJavaInfo(
         "public class Test extends Table {",
         "  public Test(Composite parent, int style) {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/TableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/TableTest.java
@@ -179,7 +179,8 @@ public class TableTest extends RcpModelTest {
    * In SWT Cocoa and Linux GTK, the column headers are excluded from the client
    * area, hence why we have to adjust them for the tests.
    */
-  public void test_TableColumn() throws Exception {
+  // Disabled because of https://github.com/eclipse/windowbuilder/issues/389
+  public void DISABLE_test_TableColumn() throws Exception {
     CompositeInfo shell =
         parseComposite(
             "class Test extends Shell {",


### PR DESCRIPTION
Until this has been addressed via #389, disabling them should prevent them from obscuring other test regressions.