### PR TITLE
Set the no-transfer-progress flag for our Maven builds.

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -30,7 +30,7 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
        run: >- 
-        mvn -V -B -fae clean verify
+        mvn -V -B -fae -ntp clean verify
     - name: Upload Test Results for Java-${{ matrix.java }}
       uses: actions/upload-artifact@v3
       if: always()


### PR DESCRIPTION
A large chunk of the build logs are filled up with log messages regarding the download progress of our project dependencies. I don't see them providing any meaningful information. In fact, they obfuscate the file and make it harder to detect actual build problems.

I also thinks it's good practice to keep the digital footprint of automatic builds as small as possible.