### PR TITLE
String representation of system colors may be ambiguous.

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/converter/ColorConverter.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/converter/ColorConverter.java
@@ -46,9 +46,14 @@ public class ColorConverter extends ExpressionConverter {
       return "(java.awt.Color) null";
     }
     // find constant value
+    for (ColorInfo colorInfo : AwtColors.getColors_System()) {
+      if (value == colorInfo.getToolkitColor()) {
+        return (String) colorInfo.getData();
+      }
+    }
+
     for (ColorInfo[] colorInfos : new ColorInfo[][]{
         AwtColors.getColors_AWT(),
-        AwtColors.getColors_System(),
         AwtColors.getColors_Swing(),}) {
       for (ColorInfo colorInfo : colorInfos) {
         if (value.equals(colorInfo.getToolkitColor())) {


### PR DESCRIPTION
When converting system colors back to Java source code, the resulting String may be system-dependent. This happens if multiple colors have the same RGB values.

For example, the textHighlight color has the RGB values (0,120,215) on Windows but (0,0,0) on Linux. It may therefore simply be represented by the color black. This means that if a screen was created on Linux, but then opened on Windows, the screen ends up using the wrong color!

In order to avoid this ambiguity, identity is used, in addition to equality. If the given color is identical one of the color constants, then its String representation is returned by the converter. Otherwise, the first compatible String representation is returned instead.

Example:
java.awt.SystemColor.textHighlight -> java.awt.SystemColor.textHighlight
java.awt.Color.BLACK -> java.awt.Color.BLACK
java.awt.Color(255,0,0) -> java.awt.Color.RED