### PR TITLE
[GTK3] Fix freeze if using GTKLookAndFeel in Swing + SWT

### DIFF
--- a/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
+++ b/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
@@ -27,7 +27,9 @@ import org.eclipse.swt.widgets.TreeItem;
 
 import org.osgi.framework.Bundle;
 
+import java.awt.EventQueue;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 /**
@@ -323,5 +325,23 @@ public abstract class OSSupport {
   public Image makeShotAwt(Object component, int width, int height) {
     // do nothing by default
     return null;
+  }
+
+  /**
+   * Executes the given runnable synchronously within the AWT event queue. If the
+   * current thread is already the AWT thread, the job is executed directly.
+   *
+   * @param job The runnable to be executed in the AWT UI thread
+   */
+  public void runAwt(Runnable job) {
+    if (EventQueue.isDispatchThread()) {
+      job.run();
+    } else {
+      try {
+        EventQueue.invokeAndWait(job);
+      } catch (InvocationTargetException | InterruptedException e) {
+        Platform.getLog(OSSupport.class).error(e.getMessage(), e);
+      }
+    }
   }
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
+import org.eclipse.wb.os.OSSupport;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Device;
@@ -177,7 +178,7 @@ public final class SwingUtils {
       }
     } else {
       // just run if in dispatch thread
-      job.run();
+      OSSupport.get().runAwt(job);
     }
   }
 


### PR DESCRIPTION
Our JUnit tests frequently get stuck on Linux while trying to draw Swing components. And I think what's happening is the following: The UI update is executed from within the main thread while at the same time, another UI update is executed from the AWT EventQueue. The way GTK handles this parallel is by occasionally locking up.

One of the comments in the SwingUtils class describes it as follows:

> Linux synchronizes GTK calls and if being invoked from different
threads it may lock up.

To solve this problem, check whether we are current in the EventQueue. If so, run the job as normal. Otherwise submit the job to the EventQueue and wait for its completion. This way, we ensure that all Swing operations are executed from within a single thread.