### PR TITLE
Perform automatic code cleanup - Organize Imports

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapLayoutConverter.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapLayoutConverter.java
@@ -22,6 +22,8 @@ import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.swt.model.widgets.ICompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.jdt.internal.core.util.ComponentInfo;
+
 import java.util.List;
 
 /**

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridLayoutConverter.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridLayoutConverter.java
@@ -22,6 +22,8 @@ import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.swt.model.widgets.ICompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.IControlInfo;
 
+import org.eclipse.jdt.internal.core.util.ComponentInfo;
+
 import java.util.List;
 
 /**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/FlowContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/FlowContainerModelTest.java
@@ -31,8 +31,8 @@ import org.eclipse.wb.tests.designer.XML.model.description.AbstractCoreTest;
 import org.eclipse.wb.tests.designer.tests.mock.EasyMockTemplate;
 import org.eclipse.wb.tests.designer.tests.mock.MockRunnable;
 
-import static org.easymock.EasyMock.expect;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.expect;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/SimpleContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/XML/model/generic/SimpleContainerModelTest.java
@@ -35,8 +35,8 @@ import org.eclipse.wb.tests.designer.core.model.TestObjectInfo;
 import org.eclipse.wb.tests.designer.tests.mock.EasyMockTemplate;
 import org.eclipse.wb.tests.designer.tests.mock.MockRunnable;
 
-import static org.easymock.EasyMock.expect;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.expect;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectInfoTest.java
@@ -24,11 +24,11 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 import org.eclipse.wb.tests.designer.tests.common.PropertyWithTitle;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.lang.ArrayUtils;
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/CompoundAssociationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/CompoundAssociationTest.java
@@ -27,8 +27,8 @@ import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 import org.eclipse.wb.tests.designer.tests.mock.EasyMockTemplate;
 import org.eclipse.wb.tests.designer.tests.mock.MockRunnable2;
 
-import static org.easymock.EasyMock.expect;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.expect;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerModelTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/generic/FlowContainerModelTest.java
@@ -31,9 +31,9 @@ import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 import org.eclipse.wb.tests.designer.tests.mock.EasyMockTemplate;
 import org.eclipse.wb.tests.designer.tests.mock.MockRunnable;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createStrictControl;
 import static org.easymock.EasyMock.expect;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.lang.StringUtils;
 import org.easymock.IMocksControl;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/AbstractTextPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/AbstractTextPropertyEditorTest.java
@@ -17,8 +17,8 @@ import org.eclipse.wb.internal.core.model.property.editor.TextDisplayPropertyEdi
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
-import static org.easymock.EasyMock.expect;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.expect;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/JavaInfoUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/util/JavaInfoUtilsTest.java
@@ -72,12 +72,12 @@ import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
 
-import static org.easymock.EasyMock.capture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.capture;
 
+import org.assertj.core.api.Assertions;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.assertj.core.api.Assertions;
 
 import java.awt.FlowLayout;
 import java.lang.reflect.Method;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/refactoring/RefactoringUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/refactoring/RefactoringUtilsTest.java
@@ -28,8 +28,8 @@ import org.eclipse.ltk.core.refactoring.participants.RefactoringParticipant;
 import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
 
-import static org.easymock.EasyMock.expect;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.expect;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/nebula/GanttChartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/nebula/GanttChartTest.java
@@ -14,6 +14,8 @@ import org.eclipse.wb.internal.rcp.nebula.ganttchart.GanttGroupEditPart;
 import org.eclipse.wb.internal.rcp.nebula.ganttchart.GanttGroupInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 
+import org.eclipse.nebula.widgets.ganttchart.GanttChart;
+
 /**
  * Test for {@link GanttChart} items models.
  *

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/nebula/GridTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/nebula/GridTest.java
@@ -20,6 +20,9 @@ import org.eclipse.wb.internal.rcp.nebula.grid.GridInfo;
 import org.eclipse.wb.internal.rcp.nebula.grid.GridItemInfo;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 
+import org.eclipse.nebula.widgets.grid.GridColumn;
+import org.eclipse.nebula.widgets.grid.GridItem;
+
 import net.miginfocom.layout.Grid;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
As part of e.g. the GEF migration, we have to adapt a lot of package names. Cleanup the packages in preparation, to avoid any unrelated file modifications.