### PR TITLE
Resolve "missing required source folder" error

### DIFF
--- a/org.eclipse.wb.core.lib/.classpath
+++ b/org.eclipse.wb.core.lib/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/toolfactory-jvm-driver-9.1.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/burningwave-core-12.53.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/burningwave-jvm-driver-8.6.0.jar"/>


### PR DESCRIPTION
The plug-in "org.eclipse.wb.core.lib" specifies the 'src' folder in its classpath, even though the bundle only contains jar. This never caused problems up until recently, until the MVEL2 jar has been deleted.

Given that this folder isn't needed, we simply have to remove this entry from the classpath.