### PR TITLE
[Oomph] Update the setup task due to changes to the target platform

### DIFF
--- a/setups/WindowBuilder.setup
+++ b/setups/WindowBuilder.setup
@@ -136,6 +136,10 @@
               url="https://download.eclipse.org/releases/${eclipse.target.platform.latest}"/>
           <repository
               url="https://download.eclipse.org/cbi/updates/license"/>
+          <repository
+              url="https://download.eclipse.org/nebula/snapshot/"/>
+          <repository
+              url="https://download.eclipse.org/nebula/incubation/snapshot/"/>
         </repositoryList>
       </targlet>
       <composedTarget>wb-mvn</composedTarget>


### PR DESCRIPTION
The Oomph setup script is no longer compatible with the current state of the WindowBuilder master. This is because the script creates a modular target platform consisting of the Maven dependencies specified in wb-mvn, as well as some hardcoded p2 repositories. We therefore miss out on the remaining update sites, which are used by Tycho (e.g. Nebula).

Instead of manually having to keep both files in sync, I think it makes more sense to use the same target platform in the IDE that is used by Tycho.

This brings the following benefits:

- Changes to the target platform are automatically integrated into Oomph.

- Code that works in the IDE is likely to also work during the build.