### PR TITLE
[JUnit] Attempt to stabilize the set-up/tear-down phase for each test.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -71,7 +71,7 @@ public class AbstractJavaProjectTest extends DesignerTestCase {
               resource.setResourceAttributes(attributes);
             }
             // do deleting
-            resource.delete(true, null);
+            forceDeleteFile(resource);
             break;
           } catch (Exception e) {
             if (i == maxCount - 1) {
@@ -206,6 +206,9 @@ public class AbstractJavaProjectTest extends DesignerTestCase {
    * problems.
    */
   public static void waitForAutoBuild() throws Exception {
+    // Wait for workspace jobs such as file creation
+    waitEventLoop(25);
+    // Wait for auto-builder to handle all newly created files
     TestProject.waitForAutoBuild();
     // check for compilation problems
     String problemsText = "";


### PR DESCRIPTION
Primarily on Windows, we get sporadic test failures of the form:
 -> /TestProject/src/test/Test.java already exists in target

This error shows up at the start of a test, when creating a new test screen. The exact reason is not clear, but it's most likely a timing issue. It might for example be that the auto-build is still running, thus preventing the Eclipse to delete the file from the file system.

This issue should be avoided by using the harsher forceDeleteFile() method, instead of calling resource.delete(). This way we can be almost certain that the file is gone, by the time the next test is executed.

Another common issue is of the form:
-> java.lang.ClassNotFoundException: test.MyComposite

This error shows up when trying to parse a Java file which hasn't been created yet. Again, the reason is not immediately obvious, but a likely reason is that the creation job has been blocked by another process. Normally, this should happen as we explicitly wait for the auto-build to finish. But there's a chance that this method is called, while the creation process is still pending. Thus a resource change event might not have been finished yet, meaning the method returns immediately.