### PR TITLE
[JUnit] Attempt to stabilize Jenkins build.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -225,6 +225,7 @@ public final class TreeRobot {
     TreeEditPart[] editParts = getEditParts(models);
     m_justSelectedEditParts = editParts;
     m_viewer.setSelection(ImmutableList.<EditPart>copyOf(editParts));
+    waitEventLoop();
     return this;
   }
 


### PR DESCRIPTION
There are currently two test failures on the Jenkins build, both in the MenuComplexTest. The first failure happens during the clean-up phase in 'test_deleteItemWithSubmenu' because the menu item couldn't be deleted in time.

This test sporadically succeeds, which makes me believe that this is a timing issue and some SWT events that are fired haven't been processed by the time we attempt to remove it. To solve this issue, pump SWT events for a short amount of time after changing the selection.

The second failure is a result of the first failure. Because the first test fails during the tearDown() call, the created Java file isn't deleted. When trying to create a new one for the next test, we fail because a file with the same name already exists.