### PR TITLE
Extend unstable tests with additional checks to isolate point-of-failure

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -18,6 +18,9 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.databinding.parser.DatabindingRootProcessor;
+import org.eclipse.wb.internal.core.databinding.parser.ParseState;
+import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.editor.DesignPage;
 import org.eclipse.wb.internal.core.editor.DesignPageSite;
 import org.eclipse.wb.internal.core.editor.actions.DesignPageActions;
@@ -33,6 +36,8 @@ import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
 import org.eclipse.wb.internal.gef.graphical.GraphicalViewer;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
+import org.eclipse.wb.internal.rcp.databinding.DatabindingsProvider;
+import org.eclipse.wb.internal.rcp.databinding.model.widgets.WidgetsObserveTypeContainer;
 import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.core.model.parser.AbstractJavaInfoRelatedTest;
 import org.eclipse.wb.tests.gef.GraphicalRobot;
@@ -310,6 +315,28 @@ public class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest {
   // Utils
   //
   ////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Returns the data bindings provider of the current compilation unit.
+   */
+  protected final DatabindingsProvider getDatabindingsProvider() throws Exception {
+    ParseState parseState = DatabindingRootProcessor.STATES.get(m_lastEditor.getModelUnit());
+    assertNotNull(parseState);
+    assertNotNull(parseState.databindingsProvider);
+    assertInstanceOf(DatabindingsProvider.class, parseState.databindingsProvider);
+    return (DatabindingsProvider) parseState.databindingsProvider;
+  }
+
+  /**
+   * Asserts existence of an SWT widget with the given name.
+   */
+  protected final void assertJavaInfo(String infoName) throws Exception {
+    DatabindingsProvider provider = getDatabindingsProvider();
+    WidgetsObserveTypeContainer container = (WidgetsObserveTypeContainer) provider.getContainer(ObserveType.WIDGETS);
+    assertNotNull(container);
+    assertNotNull(container.resolve(getJavaInfoByName(infoName)));
+  }
+
   /**
    * Asserts selection range in "Java" editor.
    */

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutGefTest.java
@@ -89,6 +89,11 @@ public class GridLayoutGefTest extends RcpGefTest {
         "    }",
         "  }",
         "}");
+
+    assertJavaInfo("composite");
+    assertJavaInfo("label");
+    assertJavaInfo("button");
+
     ControlInfo button = getJavaInfoByName("button");
     // select "button"
     canvas.select(button);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuComplexTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/menu/MenuComplexTest.java
@@ -400,8 +400,7 @@ public class MenuComplexTest extends RcpGefTest {
   /**
    * Test for deleting "item" with "subMenu"
    */
-  // Disabled due to Jenkins failure
-  public void DISABLED_test_deleteItemWithSubmenu() throws Exception {
+  public void test_deleteItemWithSubmenu() throws Exception {
     CompositeInfo shellInfo =
         openComposite(
             "public class Test extends Shell {",
@@ -422,6 +421,12 @@ public class MenuComplexTest extends RcpGefTest {
             "    }",
             "  }",
             "}");
+
+    assertJavaInfo("bar");
+    assertJavaInfo("item_1");
+    assertJavaInfo("item_2");
+    assertJavaInfo("menu_2");
+
     MenuInfo barInfo = shellInfo.getChildren(MenuInfo.class).get(0);
     MenuItemInfo item_1 = barInfo.getChildrenItems().get(0);
     MenuItemInfo item_2 = barInfo.getChildrenItems().get(1);


### PR DESCRIPTION
Create a new assertJavaInfo method, to check the whether a widget with the given name exists in the Java code. This is the underlying cause of the Jenkins failure, because no matching data binding can be found.

Furthermore, refresh the design page after it has been openend, to ensure that all data bindings are up-to-date.

Reactivate test_deleteItemWithSubmenu() as this is a general problem and not limited to just this test.