### PR TITLE
[JUnit] Pump the SWT event queue for 100ms after selecting a tree object

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -26,6 +26,7 @@ import org.eclipse.wb.internal.core.utils.execution.RunnableObjectEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
+import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DropTarget;
@@ -225,6 +226,7 @@ public final class TreeRobot {
     TreeEditPart[] editParts = getEditParts(models);
     m_justSelectedEditParts = editParts;
     m_viewer.setSelection(ImmutableList.<EditPart>copyOf(editParts));
+    DesignerTestCase.waitEventLoop(100, 0);
     return this;
   }
 


### PR DESCRIPTION
The problem is that the property table is redrawn while WB is still deleting the widget. So we're at a state where the widget has already been removed from the databinding but is still registered as selected.

When we then try to redraw the table, we attempt to fetch the no-longer-existing databinding for the widget, causing a model exception.

In short, instead of:

- Update Selection
- Update Databinding
- Redraw

We do:

- Update Selection
- Update Databinding
- Redraw <- Error

We already tried something similar with revision
ea5c81c078bb654efbe6214610e960b6dc1b0502. However just doing a single SWT event loop isn't enough.

Resolves #413