### PR TITLE
[JUnit] Gracefully handle deletion of Compilation Units on Windows.

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -551,6 +551,23 @@ public class AbstractJavaProjectTest extends DesignerTestCase {
     }
   }
 
+  /**
+   * Force deletes {@link ICompilationUnit}.
+   */
+  public static void forceDeleteCompilationUnit(ICompilationUnit cu) {
+    while (cu.exists()) {
+      try {
+        cu.getResource().refreshLocal(IResource.DEPTH_INFINITE, null);
+      } catch (Throwable e) {
+      }
+      try {
+        cu.delete(true, null);
+      } catch (Throwable e) {
+        waitEventLoop(100);
+      }
+    }
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   //
   // PNG image creation

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/ExecuteOnParseTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/ExecuteOnParseTest.java
@@ -2717,7 +2717,7 @@ public class ExecuteOnParseTest extends SwingModelTest {
       return defaultValue;
     } finally {
       if (m_lastModelUnit != null) {
-        m_lastModelUnit.delete(true, null);
+        forceDeleteCompilationUnit(m_lastModelUnit);
       }
     }
   }


### PR DESCRIPTION
Calling delete() just once may not be sufficient enough on Windows, to ensure that all files are actually removed from the file system. Use a similar approach to forceDeleteFile(), to make sure that it is cleaned up after/during a test.