### PR TITLE
Fix: "lastgoodbuild" update site misses dependent bundles

### DIFF
--- a/org.eclipse.wb.core.feature_feature/feature.xml
+++ b/org.eclipse.wb.core.feature_feature/feature.xml
@@ -97,4 +97,25 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.draw2d"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.mvel2"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.nebula.widgets.cdatetime"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Because we started replacing embedded jars with their latest version from Maven Central or the SimRel repository, it is no longer possible to install WindowBuilder in a fresh Eclipse installation due to unresolved dependencies.

While it is possible to resolve this by manually adding those update sites, this is highly inconvenient and - for Maven dependencies - not always possible.

~~Because those are 3rd-party dependencies, I don't think they should be added to a project feature, in order to avoid redundancy with other features referencing the "same" bundles (i.e. same id, different version). Instead, add them directly to the repository as uncategorized artifacts.~~

Add those plugin to the relevant WB feature, to ensure that no left-over
plugin remains, in case the feature is removed from the Eclipse
installation.