### PR TITLE
Replace the version of the SimRel feature with the 0.0.0 wildcard.

### DIFF
--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -24,7 +24,7 @@
 		<location type="Target" uri="file:${project_loc:/target-platform}/mvn/wb-mvn.target"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/oomph/simrel-maven/milestone/latest/"/>
-			<unit id="org.eclipse.oomph.maven.all.feature.group" version="4.28.0.qualifier"/>
+			<unit id="org.eclipse.oomph.maven.all.feature.group" version="0.0.0"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
The old version is no longer up-to-date, thus leading to unresolved dependencies.

We may require the latest milestone due to replacing embedded jars with their latest Maven/SimRel release. Once this is done we can switch to a fixed release, at least for the target platform.