### PR TITLE
Replace the CGLib runtime code generation in WB SWT with ByteBuddy

### DIFF
--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -61,6 +61,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.pde.core,
  org.eclipse.draw2d;bundle-version="3.13.0",
  com.google.guava;bundle-version="31.1.0",
+ net.bytebuddy.byte-buddy;bundle-version="1.14.4",
  org.apache.commons.collections;bundle-version="3.2.2"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
We use ByteBuddy/CGLib, to subclass the PluginResourceProvider, in order to inject a custom implementation of the getEntry() method.