### PR TITLE
Issue 352 - Parameterized JComboBox breaks Design tab

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstNodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstNodeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -960,12 +960,20 @@ public class AstNodeUtils {
         if (i != 0) {
           buffer.append(',');
         }
-        if (declaration && parameterType.isTypeVariable()) {
-          ITypeBinding variableBinding = getTypeVariableBound(parameterType);
+
+        // We have to unwrap the element type of arrays. Otherwise isTypeVariable()
+        // always returns false.
+        ITypeBinding elementType = parameterType.isArray() ? parameterType.getElementType() : parameterType;
+
+        if (declaration && elementType.isTypeVariable()) {
+          ITypeBinding variableBinding = getTypeVariableBound(elementType);
           if (variableBinding == null) {
             buffer.append("java.lang.Object");
           } else {
             buffer.append(getFullyQualifiedName(variableBinding, false));
+          }
+          if (parameterType.isArray()) {
+            buffer.append("[]");
           }
         } else {
           buffer.append(getFullyQualifiedName(parameterType, false));

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/SwingParserTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/SwingParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1199,6 +1199,22 @@ public class SwingParserTest extends SwingModelTest {
             "public class Test extends JPanel {",
             "  public Test() {",
             "    JComboBox combo = new JComboBox((Object[]) null);",
+            "    add(combo);",
+            "  }",
+            "}");
+    panel.refresh();
+    assertNoErrors(panel);
+  }
+
+  /**
+   * {@link JComboBox#JComboBox(T[])} should not be used with <code>null</code> argument.
+   */
+  public void test_JComboBox_constructor_Generic() throws Exception {
+    ContainerInfo panel =
+        parseContainer(
+            "public class Test extends JPanel {",
+            "  public Test() {",
+            "    JComboBox<String> combo = new JComboBox<>((String[]) null);",
             "    add(combo);",
             "  }",
             "}");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstNodeUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstNodeUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2023 Google, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -3087,6 +3087,42 @@ public class AstNodeUtilsTest extends AbstractJavaTest {
       assertEquals("foo(int,javax.swing.JButton)", getMethodSignature(binding));
       assertEquals("foo(int,T)", getMethodGenericSignature(binding));
       assertEquals("foo(int,java.lang.Object)", getMethodDeclarationSignature(binding));
+    }
+  }
+
+  /**
+   * Test for {@link AstNodeUtils#getMethodGenericSignature(IMethodBinding)} and
+   * {@link AstNodeUtils#getMethodDeclarationSignature(IMethodBinding)}
+   */
+  public void test_getMethodGenericSignature_array() throws Exception {
+    setFileContentSrc(
+        "test/MyPanel.java",
+        getSourceDQ(
+            "package test;",
+            "import javax.swing.*;",
+            "public class MyPanel extends JPanel {",
+            "  public <T> void foo(int v, T[] value) {",
+            "  }",
+            "}"));
+    waitForAutoBuild();
+    //
+    createTypeDeclaration_Test(
+        "import javax.swing.*;",
+        "public class Test extends MyPanel {",
+        "  public Test() {",
+        "    foo(0, new String[0]);",
+        "  }",
+        "}");
+    MethodInvocation invocation = getNode("foo(", MethodInvocation.class);
+    IMethodBinding binding = AstNodeUtils.getMethodBinding(invocation);
+    // check signatures
+    for (int i = 0; i < 2; i++) {
+      if (i != 0) {
+        binding = new BindingContext().get(binding);
+      }
+      assertEquals("foo(int,java.lang.String[])", getMethodSignature(binding));
+      assertEquals("foo(int,T[])", getMethodGenericSignature(binding));
+      assertEquals("foo(int,java.lang.Object[])", getMethodDeclarationSignature(binding));
     }
   }
 


### PR DESCRIPTION
The problem boils down to the fact that generic type informations are not stored inside the Java byte code. Meaning a generic method `foo(T t)` is stored as `foo(Object t)`.

In principle, WindowBuilder is able to correctly map those methods. But only for normal objects, not for arrays. This oversight has been corrected.

The reason it showed up for the JComboBox specifically is because of its generic constructor `<init>(T[] items)`, which is stored as `<init>(Object[] items)`.

Because our mapping mechanism wasn't working for arrays, we try to look up the constructor `<init>(String[] items)` when trying to instantiate the object. Because no match was found, an exception is thrown.