### PR TITLE
Fix: Can't install WB on Eclipse 4.27 and older

### DIFF
--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.eclipse.ui,
  org.apache.commons.digester;bundle-version="3.2.0",
  org.apache.commons.logging;bundle-version="1.2.0",
  org.mvel2;bundle-version="2.4.15",
- org.objectweb.asm;bundle-version="9.5.0"
+ org.objectweb.asm;bundle-version="9.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.wb.core.editor,

--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -151,7 +151,7 @@ Require-Bundle: org.eclipse.ui;visibility:=reexport,
  com.google.guava;bundle-version="31.1.0",
  net.bytebuddy.byte-buddy;bundle-version="1.14.4",
  org.apache.commons.collections;bundle-version="3.2.2",
- org.objectweb.asm;bundle-version="9.5.0",
+ org.objectweb.asm;bundle-version="9.0.0",
  org.mvel2;bundle-version="2.4.15"
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.wb.core

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.databinding,
  com.google.guava;bundle-version="31.1.0",
  org.apache.commons.collections;bundle-version="3.2.2",
- org.objectweb.asm;bundle-version="9.5.0"
+ org.objectweb.asm;bundle-version="9.0.0"
 Export-Package: org.eclipse.wb.internal.rcp.databinding,
  org.eclipse.wb.internal.rcp.databinding.model,
  org.eclipse.wb.internal.rcp.databinding.model.beans,

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -104,7 +104,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.draw2d;bundle-version="3.13.0",
  com.google.guava;bundle-version="31.1.0",
  org.apache.commons.commons-beanutils;bundle-version="1.9.4",
- org.objectweb.asm;bundle-version="9.5.0"
+ org.objectweb.asm;bundle-version="9.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.wb.rcp

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -51,7 +51,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.12.0",
  com.google.guava;bundle-version="31.1.0",
  org.apache.commons.digester;bundle-version="3.2.0",
- org.objectweb.asm;bundle-version="9.5.0"
+ org.objectweb.asm;bundle-version="9.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  lib/org.assertj_1.7.1.v20170413-2026.jar,


### PR DESCRIPTION
The Eclipse 4.27 is using ASM 9.4. However, Windowbuilder requires at
least 9.5  Because this plugin is not contained by the target platform,
WindowBuilder can't be installed due to unresolved dependencies.

Adjust the lower bounds to 9.0 in the Manifest files.