### PR TITLE
[GEF] Remove obsolete getLayer(String) method from IEditPartViewer

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/IEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,10 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.core;
 
-import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.graphical.handles.Handle;
-import org.eclipse.wb.internal.draw2d.IRootFigure;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
 import org.eclipse.draw2d.geometry.Point;
@@ -111,16 +108,6 @@ public interface IEditPartViewer extends ISelectionProvider, org.eclipse.gef.Edi
 	 * @return viewer vertical scroll offset.
 	 */
 	int getVOffset();
-
-	/**
-	 * Returns root {@link Figure} use for access to {@link Layer}'s.
-	 */
-	IRootFigure getRootFigure();
-
-	/**
-	 * Returns the layer identified by the <code>name</code> given in the input.
-	 */
-	Layer getLayer(String name);
 
 	/**
 	 * Returns the {@link EditDomain EditDomain} to which this viewer belongs.

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/GraphicalEditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/GraphicalEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,7 @@ import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.tools.DragEditPartTracker;
 import org.eclipse.wb.gef.core.tools.Tool;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
 
@@ -44,9 +45,9 @@ public abstract class GraphicalEditPart extends EditPart {
 	}
 
 	/**
-	 * The {@link Figure} into which childrens' {@link Figure}s will be added.
+	 * The {@link IFigure} into which childrens' {@link IFigure}s will be added.
 	 */
-	public Figure getContentPane() {
+	public IFigure getContentPane() {
 		return getFigure();
 	}
 

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/GraphicalEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/GraphicalEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,7 @@ import org.eclipse.wb.gef.core.policies.EditPolicy;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.gef.editparts.LayerManager;
 
 /**
  * @author lobas_av
@@ -70,7 +71,7 @@ public class GraphicalEditPolicy extends EditPolicy {
 				name = IEditPartViewer.MENU_FEEDBACK_LAYER;
 			}
 		}
-		return getHost().getViewer().getLayer(name);
+		return (Layer) LayerManager.Helper.find(getHost()).getLayer(name);
 	}
 
 	/**
@@ -100,7 +101,7 @@ public class GraphicalEditPolicy extends EditPolicy {
 	 *         {@link IEditPartViewer#MENU_PRIMARY_LAYER}.
 	 */
 	private boolean isOnMenuLayer() {
-		Layer menuPrimaryLayer = getHost().getViewer().getLayer(IEditPartViewer.MENU_PRIMARY_LAYER);
+		Layer menuPrimaryLayer = (Layer) LayerManager.Helper.find(getHost()).getLayer(IEditPartViewer.MENU_PRIMARY_LAYER);
 		for (IFigure figure = getHostFigure(); figure != null; figure = figure.getParent()) {
 			if (figure == menuPrimaryLayer) {
 				return true;

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/tools/MarqueeSelectionTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,10 +21,12 @@ import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Cursors;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
@@ -276,8 +278,8 @@ public class MarqueeSelectionTool extends Tool {
 	/**
 	 * Returns feedback layer.
 	 */
-	private Figure getFeedbackPane() {
-		return getCurrentViewer().getLayer(IEditPartViewer.FEEDBACK_LAYER);
+	private IFigure getFeedbackPane() {
+		return LayerManager.Helper.find(getCurrentViewer()).getLayer(IEditPartViewer.FEEDBACK_LAYER);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -111,7 +111,6 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 	/**
 	 * Returns root {@link Figure} use for access to {@link Layer}'s.
 	 */
-	@Override
 	public final IRootFigure getRootFigure() {
 		return getRootFigureInternal();
 	}
@@ -121,14 +120,6 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 	 */
 	protected final RootFigure getRootFigureInternal() {
 		return m_canvas.getRootFigure();
-	}
-
-	/**
-	 * Returns the layer identified by the <code>name</code> given in the input.
-	 */
-	@Override
-	public Layer getLayer(String name) {
-		return getRootFigure().getLayer(name);
 	}
 
 	/**
@@ -199,7 +190,7 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 				return editPart != null && (conditional == null || conditional.evaluate(editPart));
 			}
 		};
-		getLayer(layer).accept(visitor, false);
+		((Layer) m_rootEditPart.getLayer(layer)).accept(visitor, false);
 		return visitor.getTargetEditPart();
 	}
 
@@ -240,7 +231,7 @@ public class GraphicalViewer extends AbstractEditPartViewer {
 	 */
 	private Handle findTargetHandle(String layer, int x, int y) {
 		TargetFigureFindVisitor visitor = new TargetFigureFindVisitor(m_canvas, x, y);
-		getLayer(layer).accept(visitor, false);
+		((Layer) m_rootEditPart.getLayer(layer)).accept(visitor, false);
 		Figure targetFigure = visitor.getTargetFigure();
 		return targetFigure instanceof Handle ? (Handle) targetFigure : null;
 	}

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -12,11 +12,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.gef.tree;
 
-import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.graphical.handles.Handle;
 import org.eclipse.wb.gef.tree.TreeEditPart;
 import org.eclipse.wb.internal.core.utils.ui.UiUtils;
-import org.eclipse.wb.internal.draw2d.IRootFigure;
 import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
@@ -111,16 +109,6 @@ public class TreeViewer extends AbstractEditPartViewer {
 	@Override
 	public RootEditPart getRootEditPart() {
 		return m_rootEditPart;
-	}
-
-	@Override
-	public IRootFigure getRootFigure() {
-		return null;
-	}
-
-	@Override
-	public Layer getLayer(String name) {
-		return null;
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/header/AbstractHeaderLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/header/AbstractHeaderLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.editparts.LayerManager;
 
 /**
  * Abstract implementation of {@link LayoutEditPolicy} for headers. It provides additional utilities
@@ -57,7 +58,7 @@ public abstract class AbstractHeaderLayoutEditPolicy extends LayoutEditPolicy {
 	 * @return the {@link Layer} from main {@link IEditPartViewer} with given id.
 	 */
 	protected final Layer getMainLayer(String layerId) {
-		return getMainViewer().getLayer(layerId);
+		return (Layer) LayerManager.Helper.find(getMainViewer()).getLayer(layerId);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/header/AbstractHeaderSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/header/AbstractHeaderSelectionEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,8 @@ import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
+
+import org.eclipse.gef.editparts.LayerManager;
 
 /**
  * Abstract implementation of {@link SelectionEditPolicy} for headers. It provides additional
@@ -45,7 +47,7 @@ public abstract class AbstractHeaderSelectionEditPolicy extends SelectionEditPol
 	 * @return the {@link Layer} from main {@link IEditPartViewer} with given id.
 	 */
 	protected final Layer getMainLayer(String layerId) {
-		return getMainViewer().getLayer(layerId);
+		return (Layer) LayerManager.Helper.find(getMainViewer()).getLayer(layerId);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/PolicyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/PolicyUtils.java
@@ -34,6 +34,7 @@ import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.gef.editparts.LayerManager;
 
 import java.lang.reflect.Method;
 import java.util.Objects;
@@ -66,7 +67,7 @@ public abstract class PolicyUtils {
 	 * Shows border around given {@link GraphicalEditPart} figure.
 	 */
 	public static void showBorderTargetFeedback(GraphicalEditPart part) {
-		Layer feedbackLayer = part.getViewer().getLayer(IEditPartViewer.FEEDBACK_LAYER);
+		Layer feedbackLayer = (Layer) LayerManager.Helper.find(part.getViewer()).getLayer(IEditPartViewer.FEEDBACK_LAYER);
 		showBorderTargetFeedback(feedbackLayer, part);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,6 +36,7 @@ import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.swt.graphics.Color;
 
 import java.lang.reflect.Field;
@@ -247,7 +248,7 @@ public abstract class AbstractGridHelper {
 		prepareHostClientArea();
 		translateModelToFeedback(hostClientArea);
 		m_gridFigure.setBounds(hostClientArea);
-		getHost().getViewer().getLayer(IEditPartViewer.HANDLE_LAYER_SUB_2).add(m_gridFigure);
+		LayerManager.Helper.find(getHost()).getLayer(IEditPartViewer.HANDLE_LAYER_SUB_2).add(m_gridFigure);
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContainerEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContainerEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,6 +26,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -103,7 +104,7 @@ IHeaderMenuProvider {
 			// prepare viewer size
 			org.eclipse.swt.graphics.Point size = viewer.getControl().getSize();
 			// prepare main viewer size
-			Dimension mainSize = m_viewer.getLayer(IEditPartViewer.PRIMARY_LAYER).getSize();
+			Dimension mainSize = LayerManager.Helper.find(m_viewer).getLayer(IEditPartViewer.PRIMARY_LAYER).getSize();
 			// set bounds
 			if (m_horizontal) {
 				getFigure().setBounds(new Rectangle(0, 0, mainSize.width, size.y));

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MacMenuEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MacMenuEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,7 @@ import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.editparts.LayerManager;
 
 /**
  * {@link MenuEditPart} for MacOSX which does special handling for OSX menu bar.
@@ -65,7 +66,7 @@ public final class MacMenuEditPart extends MenuEditPart {
 	@Override
 	protected boolean addSelfVisual(int index) {
 		if (!isSubMenu()) {
-			getViewer().getLayer(IEditPartViewer.PRIMARY_LAYER).add(getFigure());
+			LayerManager.Helper.find(getViewer()).getLayer(IEditPartViewer.PRIMARY_LAYER).add(getFigure());
 			m_addedSelf = true;
 			// add invisible fake figure to the content pane to keep index right
 			GraphicalEditPart parent = (GraphicalEditPart) getParent();
@@ -77,7 +78,7 @@ public final class MacMenuEditPart extends MenuEditPart {
 	@Override
 	protected boolean removeSelfVisual() {
 		if (m_addedSelf) {
-			getViewer().getLayer(IEditPartViewer.PRIMARY_LAYER).remove(getFigure());
+			LayerManager.Helper.find(getViewer()).getLayer(IEditPartViewer.PRIMARY_LAYER).remove(getFigure());
 			FigureUtils.removeFigure(getFakeFigure());
 			m_addedSelf = false;
 			return true;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/SubmenuAwareEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/SubmenuAwareEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,9 +21,11 @@ import org.eclipse.wb.internal.core.model.menu.IMenuInfo;
 import org.eclipse.wb.internal.core.model.menu.IMenuObjectInfo;
 import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.editparts.LayerManager;
 
 import java.util.Collections;
 import java.util.List;
@@ -54,8 +56,8 @@ public abstract class SubmenuAwareEditPart extends MenuObjectEditPart {
 	//
 	/////////////////////////////////////////////////////////////////////
 	@Override
-	public final Figure getContentPane() {
-		return getViewer().getLayer(IEditPartViewer.MENU_PRIMARY_LAYER);
+	public final IFigure getContentPane() {
+		return LayerManager.Helper.find(getViewer()).getLayer(IEditPartViewer.MENU_PRIMARY_LAYER);
 	}
 
 	@Override

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/part/TreeItemEditPart.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/part/TreeItemEditPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swt.gef.part;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.graphical.GraphicalEditPart;
 import org.eclipse.wb.internal.swt.model.widgets.TreeItemInfo;
+
+import org.eclipse.draw2d.IFigure;
 
 /**
  * {@link EditPart} for {@link TreeItemInfo}.
@@ -39,7 +40,7 @@ public final class TreeItemEditPart extends ItemEditPart {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public Figure getContentPane() {
+	public IFigure getContentPane() {
 		EditPart parent = this;
 		while (parent instanceof TreeItemEditPart) {
 			parent = parent.getParent();

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/AnchorFiguresClassic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import org.eclipse.wb.core.gef.policy.PolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.LayoutPolicyUtils;
 import org.eclipse.wb.core.gef.policy.layout.generic.AbstractPopupFigure;
 import org.eclipse.wb.draw2d.Figure;
+import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.core.EditPart;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
@@ -27,6 +28,7 @@ import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.resource.ImageDescriptor;
 
@@ -160,7 +162,7 @@ public final class AnchorFiguresClassic<C extends IControlInfo> {
 			Figure figure,
 			boolean isLeading,
 			boolean isHorisontal) {
-		Figure layer = m_policy.getHost().getViewer().getLayer(IEditPartViewer.CLICKABLE_LAYER);
+		Layer layer = (Layer) LayerManager.Helper.find(m_policy.getHost()).getLayer(IEditPartViewer.CLICKABLE_LAYER);
 		// prepare rectangle for cells used by component (in layer coordinates)
 		Rectangle widgetRect;
 		{

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/form/FormHeaderLayoutEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,6 +38,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.gef.requests.SelectionRequest;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
@@ -129,8 +130,8 @@ AbstractHeaderLayoutEditPolicy {
 		if (percent > 0 && percent < 100) {
 			{
 				if (hintFeedback == null) {
-					Layer layer =
-							mainPolicy.getHost().getViewer().getLayer(IEditPartViewer.FEEDBACK_LAYER_ABV_1);
+					Layer layer = (Layer) LayerManager.Helper.find(mainPolicy.getHost())
+							.getLayer(IEditPartViewer.FEEDBACK_LAYER_ABV_1);
 					hintFeedback = new TextFeedback(layer, true);
 					hintFeedback.add();
 				}
@@ -139,7 +140,8 @@ AbstractHeaderLayoutEditPolicy {
 			}
 			{
 				if (feedback == null) {
-					Layer layer = getHost().getViewer().getLayer(IEditPartViewer.FEEDBACK_LAYER_ABV_1);
+					Layer layer = (Layer) LayerManager.Helper.find(mainPolicy.getHost())
+							.getLayer(IEditPartViewer.FEEDBACK_LAYER_ABV_1);
 					feedback = new FormHeaderEditPart.PercentFigure(isHorizontal);
 					layer.add(feedback);
 				}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,11 +12,9 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.gef.core.IEditPartFactory;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.handles.Handle;
-import org.eclipse.wb.internal.draw2d.IRootFigure;
 import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
@@ -94,16 +92,6 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 
 	@Override
 	public IEditPartFactory getEditPartFactory() {
-		return null;
-	}
-
-	@Override
-	public Layer getLayer(String name) {
-		return null;
-	}
-
-	@Override
-	public IRootFigure getRootFigure() {
 		return null;
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalRobot.java
@@ -34,6 +34,7 @@ import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Text;
@@ -876,7 +877,7 @@ public final class GraphicalRobot {
 	 * @return the list of {@link IFigure}'s on feedback {@link Layer}.
 	 */
 	public List<? extends IFigure> getFeedbackFigures() {
-		return m_viewer.getLayer(IEditPartViewer.FEEDBACK_LAYER).getChildren();
+		return LayerManager.Helper.find(m_viewer).getLayer(IEditPartViewer.FEEDBACK_LAYER).getChildren();
 	}
 
 	/**
@@ -952,7 +953,7 @@ public final class GraphicalRobot {
 		// prepare feedback's
 		List<? extends IFigure> feedbacks;
 		{
-			Layer feedbackLayer = m_viewer.getLayer(layerName);
+			Layer feedbackLayer = (Layer) LayerManager.Helper.find(m_viewer).getLayer(layerName);
 			feedbacks = feedbackLayer.getChildren();
 			assertEquals(feedbacks.size(), predicates.length, "Wrong count of feedbacks.");
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/SelectionToolTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/SelectionToolTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.wb.gef.graphical.tools.SelectionTool;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.editparts.LayerManager;
 import org.eclipse.gef.requests.SelectionRequest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -230,7 +231,7 @@ public class SelectionToolTest extends RequestTestCase {
 				addEditPart(editPart, "ChildEditPart", actualLogger, 50, 50, 70, 50);
 		//
 		MoveHandle handle = new MoveHandle(childEditPart);
-		m_viewer.getLayer(IEditPartViewer.HANDLE_LAYER).add(handle);
+		LayerManager.Helper.find(m_viewer).getLayer(IEditPartViewer.HANDLE_LAYER).add(handle);
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//


### PR DESCRIPTION
The layer can and should be accessed from the root edit part, which can be acquired using the LayerManager.Helper method.