### PR TITLE
Stabilize MigLayoutConstraintTest.test_contextMenu_ConstraintsAction

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
@@ -992,6 +992,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 					"  }",
 					"}");
 		}
+		waitEventLoop(5);
 		// open dialog, commit changes
 		new UiContext().executeAndCheck(new FailableRunnable<>() {
 			@Override


### PR DESCRIPTION
There needs to be a small delay between opening the "Constraints" dialog. Otherwise the second dialog might be closed together with the first one, leading to a "Could not find shell matching: with text 'Cell properties'" error.