### PR TITLE
[GEF] Remove excessive getFigureCanvas() method from Figure

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.draw2d;
 
-import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.FigureVisitor;
 
 import org.eclipse.draw2d.Graphics;
@@ -72,20 +71,6 @@ public class Figure extends org.eclipse.draw2d.Figure {
 			}
 			visitor.endVisit(this);
 		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Parent/Children
-	//
-	////////////////////////////////////////////////////////////////////////////
-
-	/**
-	 * @return the {@link FigureCanvas} that contains this {@link Figure}.
-	 * @noreference @nooverride
-	 */
-	public FigureCanvas getFigureCanvas() {
-		return ((Figure) getParent()).getFigureCanvas();
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/FigureUtils.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/FigureUtils.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.draw2d;
 
-import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.draw2d.RootFigure;
 
 import org.eclipse.draw2d.IFigure;
@@ -90,18 +89,6 @@ public class FigureUtils {
 			translatable.performTranslate(figure.getInsets());
 			translatable.performTranslate(figure.getLocation());
 		}
-	}
-
-	/**
-	 * Translates given {@link Translatable} from this {@link Figure} local coordinates to absolute (
-	 * {@link RootFigure} relative) coordinates.
-	 */
-	public static final void translateFigureToCanvas(Figure figure, Translatable translatable) {
-		translateFigureToAbsolute2(figure, translatable);
-		FigureCanvas figureCanvas = figure.getFigureCanvas();
-		translatable.performTranslate(
-				-figureCanvas.getViewport().getHorizontalRangeModel().getValue(),
-				-figureCanvas.getViewport().getVerticalRangeModel().getValue());
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/FigureCanvas.java
@@ -68,7 +68,7 @@ public class FigureCanvas extends org.eclipse.draw2d.FigureCanvas {
 	}
 
 	protected void setDefaultEventManager() {
-		m_rootFigure.getFigureCanvas().getLightweightSystem().setEventDispatcher(new EventManager(this));
+		getLightweightSystem().setEventDispatcher(new EventManager(this));
 	}
 
 	protected void setDefaultUpdateManager() {

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -69,17 +69,10 @@ public class RootFigure extends Figure implements IRootFigure {
 	// RootFigure
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @noreference @nooverride
-	 */
-	@Override
-	public FigureCanvas getFigureCanvas() {
-		return m_figureCanvas;
-	}
 
 	@Override
 	public UpdateManager getUpdateManager() {
-		return getFigureCanvas().getLightweightSystem().getUpdateManager();
+		return m_figureCanvas.getLightweightSystem().getUpdateManager();
 	}
 
 	/**

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/DirectTextEditPolicy.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/graphical/policies/DirectTextEditPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.gef.graphical.policies;
 
-import org.eclipse.wb.draw2d.Figure;
-import org.eclipse.wb.draw2d.FigureUtils;
-
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -156,14 +154,14 @@ public abstract class DirectTextEditPolicy extends GraphicalEditPolicy {
 	}
 
 	/**
-	 * Updates location of {@link Text} widget in host {@link Figure}.
+	 * Updates location of {@link Text} widget in host {@link IFigure}.
 	 */
 	private void relocateTextWidget() {
 		// prepare absolute bounds of host figure
 		Rectangle hostBounds;
 		{
 			hostBounds = getHostFigure().getBounds().getCopy();
-			FigureUtils.translateFigureToCanvas((Figure) getHostFigure().getParent(), hostBounds);
+			getHostFigure().translateToAbsolute(hostBounds);
 		}
 		// prepare text size
 		org.eclipse.swt.graphics.Point textSize;
@@ -191,7 +189,7 @@ public abstract class DirectTextEditPolicy extends GraphicalEditPolicy {
 
 	/**
 	 * @param hostBounds
-	 *          the absolute bounds of host {@link Figure}.
+	 *          the absolute bounds of host {@link IFigure}.
 	 * @param textSize
 	 *          the size of {@link Text} widget.
 	 *

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -129,7 +129,7 @@ public class GraphicalViewer extends AbstractEditPartViewer implements org.eclip
 	public void setEditDomain(EditDomain domain) {
 		super.setEditDomain(domain);
 		m_eventManager = new EditEventManager(m_canvas, domain, this);
-		getRootFigureInternal().getFigureCanvas().getLightweightSystem().setEventDispatcher(m_eventManager);
+		m_canvas.getLightweightSystem().setEventDispatcher(m_eventManager);
 	}
 
 	/**


### PR DESCRIPTION
The canvas is only needed to calculate the position of the text field for the Label widget. However, the coordinates can also be calculated by using translateToAbsolute().