### PR TITLE
Repair and execute PropertyTableTooltipTest

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/AbstractPropertyTableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/table/AbstractPropertyTableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,6 +17,8 @@ import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.TextDisplayPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.complex.IComplexPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.table.PropertyTable;
+import org.eclipse.wb.internal.core.model.property.table.PropertyTableTooltipHelper;
+import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.tests.designer.tests.DesignerTestCase;
 import org.eclipse.wb.tests.gef.EventSender;
 
@@ -43,8 +45,7 @@ public abstract class AbstractPropertyTableTest extends DesignerTestCase {
 		super.setUp();
 		// create GUI
 		{
-			m_shell = new Shell();
-			m_shell.setText("PropertyTable test");
+			m_shell = new Shell(SWT.NO_TRIM);
 			m_shell.setLayout(new FillLayout());
 			m_shell.setBounds(10000, 0, 300, 500);
 			//
@@ -61,6 +62,26 @@ public abstract class AbstractPropertyTableTest extends DesignerTestCase {
 	public void tearDown() throws Exception {
 		m_shell.dispose();
 		super.tearDown();
+	}
+
+	/**
+	 * Returns the currently shown tool-tip or {@code null}.
+	 */
+	protected Shell getTooltip() {
+		PropertyTableTooltipHelper tooltipHelper = m_propertyTable.getTooltipHelper();
+		return (Shell) ReflectionUtils.getFieldObject(tooltipHelper, "m_tooltip");
+	}
+
+	/**
+	 * Returns the event sender of the currently shown tool-tip or {@code null}.
+	 */
+	protected EventSender getTooltipSender() {
+		Shell shell = getTooltip();
+		if (shell == null) {
+			return null;
+		}
+		// The tool-tip is expected to contain a Label as single child
+		return new EventSender(shell.getChildren()[0]);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EventSender.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EventSender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -78,6 +78,14 @@ public class EventSender {
 	}
 
 	/**
+	 * Emulate mouse exit to given location <code>(x, y)</code>.
+	 */
+	public void mouseExit(int x, int y) {
+		Event event = createEvent(x, y, 0);
+		m_control.notifyListeners(SWT.MouseExit, event);
+	}
+
+	/**
 	 * Emulate mouse click use given location and <code>button</code>.
 	 */
 	public void click(Point location, int button) {
@@ -90,8 +98,10 @@ public class EventSender {
 	public void click(int x, int y, int button) {
 		Event event = createEvent(x, y, button);
 		m_control.notifyListeners(SWT.MouseDown, event);
-		updateStateMask(event, button);
-		m_control.notifyListeners(SWT.MouseUp, event);
+		if (!m_control.isDisposed()) {
+			updateStateMask(event, button);
+			m_control.notifyListeners(SWT.MouseUp, event);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The tool-tip tests for the property table are no longer disabled and are therefore executed as part of the automatic tests.

During the reactivation, it was discovered that one specific behavior no longer occurs; If the property text is longer than the column, a tool-tip should be shown, containing the entire text (Similar to how an SWT table behaves).