### PR TITLE
Avoid usage of deprecated Draw2D API

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/RootFigure.java
@@ -114,7 +114,7 @@ public class RootFigure extends Figure implements IRootFigure {
 	 */
 	@Override
 	public void setBounds(Rectangle bounds) {
-		Rectangle value = getBounds().setBounds(bounds).union(getPreferredSize());
+		Rectangle value = getBounds().setBounds(bounds).setSize(Dimension.max(bounds.getSize(), getPreferredSize()));
 		for (Layer layer : getLayers()) {
 			layer.setBounds(value);
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
@@ -161,7 +161,7 @@ public abstract class AbstractGridHelper {
 		Interval[] rowIntervals = gridInfo.getRowIntervals();
 		// prepare host information
 		prepareHostClientArea();
-		hostClientArea.crop(gridInfo.getInsets());
+		hostClientArea.shrink(gridInfo.getInsets());
 		// add horizontal lines
 		{
 			int y = hostClientArea.top();
@@ -257,7 +257,7 @@ public abstract class AbstractGridHelper {
 	private void prepareHostClientArea() {
 		IAbstractComponentInfo containerInfo = (IAbstractComponentInfo) getHost().getModel();
 		hostClientArea = getHost().getFigure().getBounds().getCopy();
-		hostClientArea.crop(containerInfo.getClientAreaInsets());
+		hostClientArea.shrink(containerInfo.getClientAreaInsets());
 		hostClientArea.x = hostClientArea.y = 0;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/AbsoluteComplexSelectionEditPolicy.java
@@ -117,7 +117,7 @@ public abstract class AbsoluteComplexSelectionEditPolicy<C extends IAbstractComp
 	private Dimension getParentSize(IAbstractComponentInfo parent) {
 		Rectangle compositeBounds = parent.getModelBounds().getCopy();
 		Insets clientAreaInsets = parent.getClientAreaInsets();
-		return compositeBounds.crop(clientAreaInsets).getSize().expand(-1, -1);
+		return compositeBounds.shrink(clientAreaInsets).getSize().expand(-1, -1);
 	}
 
 	private void addFeedbackToComponent(IAbstractComponentInfo widget,

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/DotsFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/DotsFeedback.java
@@ -42,7 +42,7 @@ public class DotsFeedback<C extends IAbstractComponentInfo> extends Figure {
 		FigureUtils.translateFigureToAbsolute(hostFigure, bounds);
 		IAbstractComponentInfo container =
 				(IAbstractComponentInfo) layoutEditPolicy.getHost().getModel();
-		bounds.crop(container.getClientAreaInsets());
+		bounds.shrink(container.getClientAreaInsets());
 		// set bounds
 		setBounds(bounds);
 	}

--- a/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/SwingVisualMapper.java
+++ b/org.eclipse.wb.swing.java6/src/org/eclipse/wb/internal/swing/java6/model/SwingVisualMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -94,7 +94,7 @@ public class SwingVisualMapper implements VisualMapper {
 	@Override
 	public java.awt.Rectangle getContainerInterior(String componentId) {
 		org.eclipse.draw2d.geometry.Rectangle bounds = getContainer().getModelBounds().getCopy();
-		bounds.crop(getContainer().getInsets());
+		bounds.shrink(getContainer().getInsets());
 		return new java.awt.Rectangle(0, 0, bounds.width, bounds.height);
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/AbsoluteBasedLayoutEditPolicySwing.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/AbsoluteBasedLayoutEditPolicySwing.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -90,7 +90,7 @@ AbsoluteBasedLayoutEditPolicy<ComponentInfo> {
 		IAbstractComponentInfo composite = m_layout.getContainer();
 		Rectangle compositeBounds = composite.getModelBounds().getCopy();
 		Insets clientAreaInsets = composite.getClientAreaInsets();
-		return compositeBounds.crop(clientAreaInsets).getSize();
+		return compositeBounds.shrink(clientAreaInsets).getSize();
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringLayoutEditPolicy.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/gef/policy/layout/SpringLayoutEditPolicy.java
@@ -81,7 +81,7 @@ public final class SpringLayoutEditPolicy extends AbsoluteBasedLayoutEditPolicyS
     return composite.getClientArea().getSize();*/
 		ContainerInfo container = m_layout.getContainer();
 		Rectangle bounds = container.getModelBounds().getCopy();
-		bounds.crop(container.getInsets());
+		bounds.shrink(container.getInsets());
 		return bounds.getSize();
 	}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/AbsoluteBasedLayoutEditPolicySWT.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/gef/policy/layout/AbsoluteBasedLayoutEditPolicySWT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -88,6 +88,6 @@ AbsoluteBasedLayoutEditPolicy<C> {
 		IAbstractComponentInfo composite = m_layout.getComposite();
 		Rectangle compositeBounds = composite.getModelBounds().getCopy();
 		Insets clientAreaInsets = composite.getClientAreaInsets();
-		return compositeBounds.crop(clientAreaInsets).getSize();
+		return compositeBounds.shrink(clientAreaInsets).getSize();
 	}
 }

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/FormLayoutInfo.java
@@ -315,9 +315,9 @@ public final class FormLayoutInfo extends LayoutInfo implements IFormLayoutInfo<
 		AbstractComponentInfo composite = getComposite();
 		Rectangle compositeBounds = composite.getModelBounds().getCopy();
 		Insets clientAreaInsets = composite.getClientAreaInsets();
-		compositeBounds.crop(clientAreaInsets);
+		compositeBounds.shrink(clientAreaInsets);
 		Insets marginInsets = FormUtils.getLayoutMargins(this);
-		return compositeBounds.crop(marginInsets).getSize();
+		return compositeBounds.shrink(marginInsets).getSize();
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- The crop() method has been replaced by shrink() method.
- The union() method has been replaced by a combination of Dimension.max() and Figure.setSize().