### PR TITLE
Migrate TextFeedback to use plain Draw2D labels

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/VerticalLabel.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/VerticalLabel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,17 +13,12 @@
 package org.eclipse.wb.internal.draw2d;
 
 import org.eclipse.wb.draw2d.FigureUtils;
-import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Insets;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Display;
+import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
  * A Label which draws its text vertically.
@@ -34,8 +29,13 @@ public final class VerticalLabel extends Label {
 	private Dimension m_preferredSize;
 
 	@Override
-	protected void paintClientArea(Graphics graphics) {
-		drawVerticalText(getText(), 0, 0, graphics, false);
+	protected void paintFigure(Graphics graphics) {
+		graphics.fillRectangle(getBounds());
+		Rectangle r = getClientArea();
+		graphics.translate(r.getLocation());
+		graphics.translate(r.width, 0);
+		graphics.rotate(90);
+		graphics.drawText(getText(), 0, 0);
 	}
 
 	/**
@@ -56,74 +56,5 @@ public final class VerticalLabel extends Label {
 	public void invalidate() {
 		m_preferredSize = null;
 		super.invalidate();
-	}
-
-	/**
-	 * Draws text vertically (rotates plus or minus 90 degrees). Uses the current font, color, and
-	 * background.
-	 *
-	 * @param string
-	 *          the text to draw
-	 * @param x
-	 *          the x coordinate of the top left corner of the drawing rectangle
-	 * @param y
-	 *          the y coordinate of the top left corner of the drawing rectangle
-	 * @param graphics
-	 *          the GC on which to draw the text
-	 */
-	private static void drawVerticalText(String string, int x, int y, Graphics graphics, boolean isUp) {
-		// Get the current display
-		Display display = Display.getCurrent();
-		if (display == null) {
-			SWT.error(SWT.ERROR_THREAD_INVALID_ACCESS);
-		}
-		// Determine string's dimensions
-		Point pt = ((GC) ReflectionUtils.getFieldObject(graphics, "gc")).textExtent(string);
-		// Create an image the same size as the string
-		Image stringImage = new Image(display, pt.x, pt.y);
-		// Create a GC so we can draw the image
-		GC stringGc = new GC(stringImage);
-		// Set attributes from the original GC to the new GC
-		stringGc.setForeground(graphics.getForegroundColor());
-		stringGc.setBackground(graphics.getBackgroundColor());
-		stringGc.setFont(graphics.getFont());
-		// Draw the text onto the image
-		stringGc.drawText(string, 0, 0);
-		// Draw the image vertically onto the original GC
-		Image rotatedImage = rotateImage(stringImage, isUp);
-		// Draw the vertical image onto the original GC
-		graphics.drawImage(rotatedImage, x, y);
-		// Dispose
-		rotatedImage.dispose();
-		stringGc.dispose();
-		stringImage.dispose();
-	}
-
-	/**
-	 * Rotates an image vertically (rotates plus or minus 90 degrees)
-	 */
-	private static Image rotateImage(Image image, boolean up) {
-		// Get the current display
-		Display display = Display.getCurrent();
-		if (display == null) {
-			SWT.error(SWT.ERROR_THREAD_INVALID_ACCESS);
-		}
-		// Use the image's data to create a rotated image's data
-		ImageData sd = image.getImageData();
-		ImageData dd = new ImageData(sd.height, sd.width, sd.depth, sd.palette);
-		// Determine which way to rotate, depending on up or down
-		// Run through the horizontal pixels
-		for (int sx = 0; sx < sd.width; sx++) {
-			// Run through the vertical pixels
-			for (int sy = 0; sy < sd.height; sy++) {
-				// Determine where to move pixel to in destination image data
-				int dx = up ? sy : sd.height - sy - 1;
-				int dy = up ? sd.width - sx - 1 : sx;
-				// Swap the x, y source data to y, x in the destination
-				dd.setPixel(dx, dy, sd.getPixel(sx, sy));
-			}
-		}
-		// Create the vertical image
-		return new Image(display, dd);
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/TextFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,14 +13,14 @@
 package org.eclipse.wb.core.gef.figure;
 
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.draw2d.border.Border;
-import org.eclipse.wb.draw2d.border.CompoundBorder;
-import org.eclipse.wb.draw2d.border.LineBorder;
-import org.eclipse.wb.draw2d.border.MarginBorder;
-import org.eclipse.wb.internal.draw2d.Label;
 import org.eclipse.wb.internal.draw2d.VerticalLabel;
 
+import org.eclipse.draw2d.Border;
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.CompoundBorder;
+import org.eclipse.draw2d.Label;
+import org.eclipse.draw2d.LineBorder;
+import org.eclipse.draw2d.MarginBorder;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;


### PR DESCRIPTION
This adapts the VerticalLabel to extend the Draw2D Label class, rather than our copy, in order to clean up the usage in the TextFeedback class.

There is no benefit to using our classes over the upstream classes and migrating makes it possible to remove them at a later stage.