### PR TITLE
Avoid usage of deprecated ResourceManager methods

### DIFF
--- a/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObserveLabelProvider.java
+++ b/org.eclipse.wb.core.databinding/src/org/eclipse/wb/internal/core/databinding/ui/providers/ObserveLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,6 +58,6 @@ public class ObserveLabelProvider extends LabelProvider {
 
 	@Override
 	public Image getImage(final Object element) {
-		return ExecutionUtils.runObjectLog(() -> m_resourceManager.createImage(getPresentation(element).getImageDescriptor()), null);
+		return ExecutionUtils.runObjectLog(() -> m_resourceManager.create(getPresentation(element).getImageDescriptor()), null);
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PaletteManagerDialog.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/dialogs/PaletteManagerDialog.java
@@ -371,7 +371,7 @@ public final class PaletteManagerDialog extends ResizableTitleAreaDialog {
 			public Image getImage(Object element) {
 				if (element instanceof EntryInfo) {
 					return Optional.ofNullable(((EntryInfo) element).getIcon()) //
-							.map(m_resourceManager::createImage) //
+							.map(m_resourceManager::create) //
 							.orElse(null);
 				}
 				return IMAGE_CATEGORY;

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/PropertiesComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/PropertiesComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -491,7 +491,7 @@ public final class PropertiesComposite extends Composite {
 					return DesignerPlugin.getImageDescriptor("nls/property.gif");
 				}
 			}, null);
-			return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
+			return imageDescriptor == null ? null : m_resourceManager.create(imageDescriptor);
 		}
 	}
 }

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/SourceComposite.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/nls/ui/SourceComposite.java
@@ -590,7 +590,7 @@ public final class SourceComposite extends Composite {
 					final JavaInfo component = components.iterator().next();
 					final ImageDescriptor imageDescriptor = ExecutionUtils
 							.runObjectLog(() -> component.getPresentation().getIcon(), null);
-					return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
+					return imageDescriptor == null ? null : m_resourceManager.create(imageDescriptor);
 				}
 			}
 			return null;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -480,7 +480,7 @@ public final class PaletteComposite extends Composite {
 		 */
 		public void onPreferencesUpdate() {
 			FontDescriptor fontDescriptor = m_preferences.getCategoryFontDescriptor();
-			setFont(fontDescriptor == null ? null : m_resourceManager.createFont(fontDescriptor));
+			setFont(fontDescriptor == null ? null : m_resourceManager.create(fontDescriptor));
 			for (Iterator<? extends IFigure> I = getChildren().iterator(); I.hasNext();) {
 				EntryFigure entryFigure = (EntryFigure) I.next();
 				entryFigure.onPreferencesUpdate();
@@ -820,7 +820,7 @@ public final class PaletteComposite extends Composite {
 		 */
 		public void onPreferencesUpdate() {
 			FontDescriptor fontDescriptor = m_preferences.getEntryFontDescriptor();
-			setFont(fontDescriptor == null ? null : m_resourceManager.createFont(fontDescriptor));
+			setFont(fontDescriptor == null ? null : m_resourceManager.create(fontDescriptor));
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -1159,7 +1159,7 @@ public final class PaletteComposite extends Composite {
 		private Image getIcon() {
 			ImageDescriptor icon = m_entry.getIcon();
 			if (icon != null) {
-				return m_resourceManager.createImage(icon);
+				return m_resourceManager.create(icon);
 			}
 			return NO_ICON;
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsLabelProvider.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/ObjectsLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -44,7 +44,7 @@ public final class ObjectsLabelProvider extends LabelProvider {
 	@Override
 	public Image getImage(final Object element) {
 		ImageDescriptor imageDescriptor = ObjectInfo.getImageDescriptor((ObjectInfo) element);
-		return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
+		return imageDescriptor == null ? null : m_resourceManager.create(imageDescriptor);
 	}
 
 	@Override

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding;singleton:=true
-Bundle-Version: 1.10.200.qualifier
+Bundle-Version: 1.10.300.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ChooseClassAndTreePropertiesUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ChooseClassAndTreePropertiesUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -420,7 +420,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		@Override
 		public Image getImage(Object element) {
 			try {
-				return m_resourceManager.createImage(getAdapterProperty(element).getPresentation().getImageDescriptor());
+				return m_resourceManager.create(getAdapterProperty(element).getPresentation().getImageDescriptor());
 			} catch (Throwable e) {
 			}
 			return super.getImage(element);

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ViewerColumnsUiContentProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/ui/contentproviders/ViewerColumnsUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -283,7 +283,7 @@ public class ViewerColumnsUiContentProvider extends UiContentProviderAdapter {
 			if (column == 0) {
 				// Viewer column
 				final VirtualEditingSupportInfo editingSupport = (VirtualEditingSupportInfo) element;
-				return ExecutionUtils.runObjectLog(() -> m_resourceManager.createImage(editingSupport.getViewerColumn().getPresentation().getImageDescriptor()), null);
+				return ExecutionUtils.runObjectLog(() -> m_resourceManager.create(editingSupport.getViewerColumn().getPresentation().getImageDescriptor()), null);
 			}
 			return null;
 		}

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ChooseClassAndPropertiesUiContentProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ChooseClassAndPropertiesUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -450,7 +450,7 @@ org.eclipse.wb.internal.core.databinding.ui.editor.contentproviders.ChooseClassA
 		@Override
 		public Image getImage(Object element) {
 			try {
-				return m_resourceManager.createImage(getAdapterProperty(element).getPresentation().getImageDescriptor());
+				return m_resourceManager.create(getAdapterProperty(element).getPresentation().getImageDescriptor());
 			} catch (Throwable e) {
 			}
 			return super.getImage(element);

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ColumnBindingUiContentProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/ColumnBindingUiContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -497,7 +497,7 @@ public final class ColumnBindingUiContentProvider implements IUiContentProvider 
 		@Override
 		public Image getImage(Object element) {
 			try {
-				return m_resourceManager.createImage(getAdapterProperty(element).getPresentation().getImageDescriptor());
+				return m_resourceManager.create(getAdapterProperty(element).getPresentation().getImageDescriptor());
 			} catch (Throwable e) {
 			}
 			return super.getImage(element);

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ContentAssistProcessor.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ContentAssistProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -153,7 +153,7 @@ public final class ContentAssistProcessor implements IContentAssistProcessor {
 			String propertyName = observe.getPresentation().getText();
 			String data = begin + propertyName + end;
 			Image image = Optional.ofNullable(observe.getPresentation().getImageDescriptor()) //
-					.map(m_resourceManager::createImage) //
+					.map(m_resourceManager::create) //
 					.orElse(null);
 			// add proposal
 			proposals[i] =

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/wizards/autobindings/ObservePropertyAdapterLabelProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/wizards/autobindings/ObservePropertyAdapterLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -47,7 +47,7 @@ public final class ObservePropertyAdapterLabelProvider extends LabelProvider {
 	public Image getImage(Object element) {
 		try {
 			ObservePropertyAdapter adapter = (ObservePropertyAdapter) element;
-			return m_resourceManager.createImage(adapter.getObserve().getPresentation().getImageDescriptor());
+			return m_resourceManager.create(adapter.getObserve().getPresentation().getImageDescriptor());
 		} catch (Throwable e) {
 			return null;
 		}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/WidgetSelectDialog.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/form/WidgetSelectDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -225,7 +225,7 @@ public class WidgetSelectDialog<C extends IAbstractComponentInfo> extends Resiza
 			C info = (C) element;
 			try {
 				ImageDescriptor imageDescriptor = info.getPresentation().getIcon();
-				return imageDescriptor == null ? null : m_resourceManager.createImage(imageDescriptor);
+				return imageDescriptor == null ? null : m_resourceManager.create(imageDescriptor);
 			} catch (Throwable e) {
 				throw ReflectionUtils.propagate(e);
 			}

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/image/ImagePropertyEditor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/property/editor/image/ImagePropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,7 +60,7 @@ public final class ImagePropertyEditor extends AbstractImagePropertyEditor {
 	 * @param javaInfo Java info the resource manager belongs to.
 	 * @param location the class whose resource directory contain the file
 	 * @param filename the file name
-	 * @return {@code LocalResourceManager.createImage(ImageDescriptor.createFromFile(<clazz>, <path>))}
+	 * @return {@code LocalResourceManager.create(ImageDescriptor.createFromFile(<clazz>, <path>))}
 	 * @see ImageDescriptor#createFromFile(Class, String)
 	 */
 	public static String getInvocationSource(JavaInfo javaInfo, String location, String filename) throws Exception {


### PR DESCRIPTION
Instead of calling e.g. createImage() and createFont(), one should use the generic create() method instead.