### PR TITLE
Repair image-related Swing tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -430,7 +430,24 @@ public abstract class AbstractJavaProjectTest extends DesignerTestCase {
 	}
 
 	/**
-	 * Creates/updates {@link IFile} with given folder/name, relative to "src" folder.
+	 * Creates/updates {@link IFile} with given path, relative to "src" folder.
+	 */
+	public static IFile setFileContentSrc(String path, byte[] content) throws Exception {
+		return setFileContent("src/" + path, content);
+	}
+
+	/**
+	 * Creates/updates {@link IFile} with given path, relative to {@link IProject}.
+	 */
+	public static IFile setFileContent(String path, byte[] content) throws Exception {
+		IFile file = getFile(path);
+		setFileContent(file, content);
+		return file;
+	}
+
+	/**
+	 * Creates/updates {@link IFile} with given folder/name, relative to "src"
+	 * folder.
 	 *
 	 * @return the created/updated {@link IFile}.
 	 */

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -36,6 +36,7 @@ import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
 import org.eclipse.wb.internal.swing.model.component.ContainerInfo;
 import org.eclipse.wb.internal.swing.model.component.JToolBarInfo;
 import org.eclipse.wb.internal.swing.palette.ActionUseEntryInfo;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 import org.eclipse.wb.tests.designer.swing.SwingTestUtils;
 
@@ -55,7 +56,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -1594,10 +1594,10 @@ public class ActionTest extends SwingModelTest {
 	/**
 	 * Test for {@link ActionInfo#getPresentation()}.
 	 */
-	@Disabled
 	@Test
 	public void test_presentation() throws Exception {
 		m_waitForAutoBuild = true;
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		ContainerInfo panel =
 				parseContainer(
 						"public class Test extends JPanel {",
@@ -1605,7 +1605,7 @@ public class ActionTest extends SwingModelTest {
 						"  private Action action_2 = new Action_2();",
 						"  private class Action_1 extends AbstractAction {",
 						"    public Action_1() {",
-						"      putValue(SMALL_ICON, new ImageIcon(Test.class.getResource('/javax/swing/plaf/basic/icons/JavaCup16.png')));",
+						"      putValue(SMALL_ICON, new ImageIcon(Test.class.getResource('/Test.png')));",
 						"    }",
 						"    public void actionPerformed(ActionEvent e) {",
 						"    }",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/IconPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/IconPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -99,13 +99,14 @@ public class IconPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getText_Class_getResource_1() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertIconPropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JPanel {",
 						"  public Test() {",
 						"    JButton button = new JButton();",
-						"    button.setIcon(new ImageIcon(Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\")));",
+						"    button.setIcon(new ImageIcon(Test.class.getResource(\"/Test.png\")));",
 						"    add(button);",
 						"  }",
 				"}"});
@@ -113,14 +114,15 @@ public class IconPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getText_Class_getResource_2() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertIconPropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JPanel {",
 						"  public Test() {",
 						"    JButton button = new JButton();",
 						"    button.setIcon("
-								+ "      new ImageIcon(Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"), "
+								+ "      new ImageIcon(Test.class.getResource(\"/Test.png\"), "
 								+ "      \"Some description\"));",
 								"    add(button);",
 								"  }",
@@ -129,13 +131,14 @@ public class IconPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getText_Class_getResource_3() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertIconPropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JPanel {",
 						"  public Test() {",
 						"    JButton button = new JButton();",
-						"    Icon icon = new ImageIcon(Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"));",
+						"    Icon icon = new ImageIcon(Test.class.getResource(\"/Test.png\"));",
 						"    button.setIcon(icon);",
 						"    add(button);",
 						"  }",
@@ -144,13 +147,14 @@ public class IconPropertyEditorTest extends SwingModelTest {
 
 	@Test
 	public void test_getText_Class_getResource_4() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertIconPropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JPanel {",
 						"  public Test() {",
 						"    JButton button = new JButton();",
-						"    java.net.URL url = Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\");",
+						"    java.net.URL url = Test.class.getResource(\"/Test.png\");",
 						"    Icon icon = new ImageIcon(url);",
 						"    button.setIcon(icon);",
 						"    add(button);",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/ImagePropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/ImagePropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,6 @@ import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
 import org.eclipse.core.resources.IFile;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -69,42 +68,42 @@ public class ImagePropertyEditorTest extends SwingModelTest {
 		}
 	}
 
-	@Disabled
 	@Test
 	public void test_getText_Class_getResource_1() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertImagePropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JFrame {",
 						"  public Test() {",
-						"    setIconImage(Toolkit.getDefaultToolkit().getImage(Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\")));",
+						"    setIconImage(Toolkit.getDefaultToolkit().getImage(Test.class.getResource(\"/Test.png\")));",
 						"  }",
 				"}"});
 	}
 
-	@Disabled
 	@Test
 	public void test_getText_Class_getResource_2() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertImagePropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JFrame {",
 						"  public Test() {",
-						"    Image icon = Toolkit.getDefaultToolkit().getImage(Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"));",
+						"    Image icon = Toolkit.getDefaultToolkit().getImage(Test.class.getResource(\"/Test.png\"));",
 						"    setIconImage(icon);",
 						"  }",
 				"}"});
 	}
 
-	@Disabled
 	@Test
 	public void test_getText_Class_getResource_3() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assertImagePropertyText(
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
+				"Classpath: /Test.png",
 				new String[]{
 						"public class Test extends JFrame {",
 						"  public Test() {",
-						"    java.net.URL url = Test.class.getResource(\"/javax/swing/plaf/basic/icons/JavaCup16.png\");",
+						"    java.net.URL url = Test.class.getResource(\"/Test.png\");",
 						"    Image icon = Toolkit.getDefaultToolkit().getImage(url);",
 						"    setIconImage(icon);",
 						"  }",


### PR DESCRIPTION
Those tests reference the JDK-internal "JavaCup16.png" file, which is no longer accessible with Java 9. Instead, the test now create and use a local project file.