### PR TITLE
Remove dependency to deprecated StringUtils.equals(...)

### DIFF
--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.java;singleton:=true
-Bundle-Version: 1.13.200.qualifier
+Bundle-Version: 1.13.300.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/UndoManager.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/UndoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,11 +33,11 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.Display;
 
 import org.apache.commons.collections4.map.LRUMap;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Manager for handling undo/redo modifications in {@link ICompilationUnit}.
@@ -84,7 +84,7 @@ public final class UndoManager {
 	public void activate() {
 		if (!m_active) {
 			m_active = true;
-			if (!StringUtils.equals(m_currentSource, m_buffer.getContents())) {
+			if (!Objects.equals(m_currentSource, m_buffer.getContents())) {
 				refreshDesignerEditor();
 			}
 			addBufferListener();

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/InvocationEvaluator.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/eval/evaluators/InvocationEvaluator.java
@@ -51,7 +51,6 @@ import net.bytebuddy.implementation.SuperMethodCall;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -129,7 +128,7 @@ public final class InvocationEvaluator implements IExpressionEvaluator {
 		Javadoc javadoc = methodDeclaration.getJavadoc();
 		if (javadoc != null) {
 			for (TagElement tag : DomGenerics.tags(javadoc)) {
-				if (StringUtils.equals(tag.getTagName(), "@wbp.eval.method.return")) {
+				if ("@wbp.eval.method.return".equals(tag.getTagName())) {
 					List<ASTNode> fragments = DomGenerics.fragments(tag);
 					if (!fragments.isEmpty() && fragments.get(0) instanceof TextElement) {
 						TextElement textElement = (TextElement) tag.fragments().get(0);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -92,19 +92,19 @@ public final class PropertyCategory {
 	 */
 	public static PropertyCategory get(String text, PropertyCategory defaultCategory) {
 		// simple
-		if (StringUtils.equals(text, "normal")) {
+		if ("normal".equals(text)) {
 			return NORMAL;
 		}
-		if (StringUtils.equals(text, "preferred")) {
+		if ("preferred".equals(text)) {
 			return PREFERRED;
 		}
-		if (StringUtils.equals(text, "advanced")) {
+		if ("advanced".equals(text)) {
 			return ADVANCED;
 		}
-		if (StringUtils.equals(text, "advanced-really")) {
+		if ("advanced-really".equals(text)) {
 			return ADVANCED_REALLY;
 		}
-		if (StringUtils.equals(text, "hidden")) {
+		if ("hidden".equals(text)) {
 			return HIDDEN;
 		}
 		// system

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/PropertyUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/util/PropertyUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -92,7 +93,7 @@ public final class PropertyUtils {
 	}
 	public static Property getByTitle(List<Property> properties, String title) {
 		for (Property property : properties) {
-			if (StringUtils.equals(title, property.getTitle())) {
+			if (Objects.equals(title, property.getTitle())) {
 				return property;
 			}
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/DocumentElement.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/DocumentElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.print.attribute.DocAttribute;
 
@@ -97,7 +98,7 @@ public class DocumentElement extends AbstractDocumentObject {
 	 * Sets the name of tag.
 	 */
 	public void setTag(String tag) {
-		if (!StringUtils.equals(m_tag, tag)) {
+		if (!Objects.equals(m_tag, tag)) {
 			String oldValue = m_tag;
 			m_tag = tag;
 			firePropertyChanged(this, P_XML_TAG_NAME, oldValue, m_tag);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/DocumentTextNode.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/xml/DocumentTextNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.utils.xml;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.Objects;
 
 /**
  * Node for text inside of some XML element.
@@ -57,7 +57,7 @@ public final class DocumentTextNode extends AbstractDocumentObject {
 	private String m_text;
 
 	public void setText(String text) {
-		if (!StringUtils.equals(m_text, text)) {
+		if (!Objects.equals(m_text, text)) {
 			String oldValue = m_text;
 			m_text = text;
 			firePropertyChanged(this, P_TEXT, oldValue, m_text);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutInfo.java
@@ -53,7 +53,6 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Menu;
 
-import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.prefs.Preferences;
 
 import java.awt.Component;
@@ -61,6 +60,7 @@ import java.awt.Container;
 import java.awt.LayoutManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Abstract model for {@link LayoutManager}.
@@ -462,7 +462,7 @@ public class LayoutInfo extends JavaInfo {
 		ClassLoader editorLoader = null;
 		Class<?> layoutClass = null;
 		for (LayoutDescription description : descriptions) {
-			if (StringUtils.equals(defaultValue, description.getId())) {
+			if (Objects.equals(defaultValue, description.getId())) {
 				creationId = description.getCreationId();
 				editorLoader = EditorState.get(getContainer().getEditor()).getEditorLoader();
 				layoutClass = editorLoader.loadClass(description.getLayoutClassName());

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.7.100-SNAPSHOT</version>
+  <version>1.7.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 	<properties>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/AbstractPaletteTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/palette/AbstractPaletteTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,8 +21,9 @@ import org.eclipse.wb.internal.core.editor.palette.PaletteManager;
 import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.swing.SwingModelTest;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
+
+import java.util.Objects;
 
 import javax.swing.JPanel;
 
@@ -168,7 +169,7 @@ public abstract class AbstractPaletteTest extends SwingModelTest {
 		PaletteInfo palette = loadPalette();
 		for (CategoryInfo category : palette.getCategories()) {
 			for (EntryInfo entry : category.getEntries()) {
-				if (StringUtils.equals(entry.getId(), id)) {
+				if (Objects.equals(entry.getId(), id)) {
 					return entry;
 				}
 			}


### PR DESCRIPTION
Use Objects.equals(...) in case it's not obvious whether one of the strings are null, otherwise invert the logic so that the equals() method of a non-null string is called.