### PR TITLE
Move re-layout of SWT container to EmbeddedSwingComposite

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafPreferencePage.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafPreferencePage.java
@@ -585,10 +585,8 @@ IPreferenceConstants {
 						return;
 					}
 					LookAndFeel lookAndFeel = selectedLAF.getLookAndFeelInstance();
-					m_previewGroup.getParent().layout(true);
 					configureLAF(lookAndFeel);
 					createPreviewArea(m_previewGroup);
-					m_previewGroup.getParent().layout(true);
 				} finally {
 					m_previewGroup.getParent().setRedraw(true);
 				}

--- a/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
+++ b/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
@@ -353,11 +353,7 @@ public abstract class EmbeddedSwingComposite extends Composite {
 			container.getRootPane().getContentPane().add(swingComponent);
 			setComponentFont();
 			// force re-layout on SWT level
-			/*getDisplay().syncExec(new Runnable() {
-		public void run() {
-			getParent().layout();
-		}
-      });*/
+			getDisplay().asyncExec(() -> getParent().requestLayout());
 		});
 	}
 


### PR DESCRIPTION
The Swing preview is created from the EventDispatcher thread, which is different from the SWT thread. Depending on the timing, this might mean that the layout done before the preview is created.

With this change, the layout is now always done after the Swing components have been created, avoiding this problem. But unlike the previous implementation, this layout must be scheduled asynchronously, to avoid both UI threads being blocked at the same time.