### PR TITLE
Remove obsolete "ClassLoader" attribute for LookAndFeel UIManager

### DIFF
--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing;singleton:=true
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.10.400.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafSupport.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -334,7 +334,6 @@ public final class LafSupport {
 				@Override
 				public void run() throws Exception {
 					LookAndFeel lookAndFeelInstance = lafInfo.getLookAndFeelInstance();
-					UIManager.put("ClassLoader", lookAndFeelInstance.getClass().getClassLoader());
 					UIManager.setLookAndFeel(lookAndFeelInstance);
 				}
 			});

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafPreferencePage.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/preferences/laf/LafPreferencePage.java
@@ -854,7 +854,6 @@ IPreferenceConstants {
 	// https://github.com/eclipse-windowbuilder/windowbuilder/discussions/937
 	private static void configureLAF(LookAndFeel lookAndFeel) {
 		SwingUtils.runLog(() -> {
-			UIManager.put("ClassLoader", lookAndFeel.getClass().getClassLoader());
 			UIManager.setLookAndFeel(lookAndFeel);
 		});
 	}


### PR DESCRIPTION
It's still not clear why this property is set or whether it's even supported, but it seems like this is related to an ancient Java 1.2 bug:

https://bugs.openjdk.org/browse/JDK-4155617

To summarize, with Java 1.2.1, the LookAndFeel was calculated using:
- Class.forName(className)

Which makes it impossible load custom LookAndFeels that are not on the Swing classpath. The bug proposes a solution to this problem by setting the "ClassLoader" attribute.

However, this proposal seems to have been discarded. With Java 1.2.2, the following snippet was used to the LookAndFeel:
- Class.forName(className, true, ClassLoader.getSystemClassLoader())

With Java 1.4.0, this the system class-loader was replaced with the context class-loader, which is what's still used today.

Furthermore, the class-loader is only relevant when the fully qualified class-name is given. But WindowBuilder supplies an instance of the LookAndFeel, meaning that even if this mechanism were to exist, it is not applied here.