### PR TITLE
Avoid deprecated StringUtils.replace() for template strings

### DIFF
--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.java;singleton:=true
-Bundle-Version: 1.13.200.qualifier
+Bundle-Version: 1.13.300.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/wizards/TemplateDesignWizardPage.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/wizards/TemplateDesignWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -165,20 +165,18 @@ public abstract class TemplateDesignWizardPage extends AbstractDesignWizardPage 
 	 */
 	protected String performSubstitutions(String code, ImportsManager imports) {
 		loadUIClasses();
-		code = StringUtils.replace(code, "%TypeName%", getTypeName());
-		code = StringUtils.replace(code, "%DefaultFormSize%", getDefaultFormSize());
-		code = StringUtils.replace(code, "%this%", getInstanceFieldQualification());
+		code = code.replace("%TypeName%", getTypeName());
+		code = code.replace("%DefaultFormSize%", getDefaultFormSize());
+		code = code.replace("%this%", getInstanceFieldQualification());
 		code = performFieldPrefixesSubstitutions(code);
 		return code;
 	}
 
 	protected static String performFieldPrefixesSubstitutions(String code) {
-		code = StringUtils.replace(
-				code,
+		code = code.replace(
 				"%field-prefix%",
 				JavaCore.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES));
-		code = StringUtils.replace(
-				code,
+		code = code.replace(
 				"%static-field-prefix%",
 				JavaCore.getOption(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES));
 		return code;

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding;singleton:=true
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.10.400.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/wizards/autobindings/SwtDatabindingProvider.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/wizards/autobindings/SwtDatabindingProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -243,20 +243,20 @@ public class SwtDatabindingProvider extends DefaultAutomaticDatabindingProvider 
 		String beanClassShortName = ClassUtils.getShortClassName(beanClassName);
 		String fieldPrefix = JavaCore.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES);
 		String fieldName = fieldPrefix + StringUtils.uncapitalize(beanClassShortName);
-		code = StringUtils.replace(code, "%BeanClass%", beanClassName);
+		code = code.replace("%BeanClass%", beanClassName);
 		//
 		if (ReflectionUtils.getConstructorBySignature(m_beanClass, "<init>()") == null) {
-			code = StringUtils.replace(code, "%BeanField%", fieldName);
+			code = code.replace("%BeanField%", fieldName);
 		} else {
-			code = StringUtils.replace(code, "%BeanField%", fieldName + " = new " + beanClassName + "()");
+			code = code.replace("%BeanField%", fieldName + " = new " + beanClassName + "()");
 		}
 		//
 		IPreferenceStore preferences = ToolkitProvider.DESCRIPTION.getPreferences();
 		String accessPrefix =
 				preferences.getBoolean(FieldUniqueVariableSupport.P_PREFIX_THIS) ? "this." : "";
-		code = StringUtils.replace(code, "%BeanFieldAccess%", accessPrefix + fieldName);
+		code = code.replace("%BeanFieldAccess%", accessPrefix + fieldName);
 		//
-		code = StringUtils.replace(code, "%BeanName%", StringUtils.capitalize(beanClassShortName));
+		code = code.replace("%BeanName%", StringUtils.capitalize(beanClassShortName));
 		// prepare code
 		StringBuffer widgetFields = new StringBuffer();
 		StringBuffer widgets = new StringBuffer();
@@ -351,11 +351,11 @@ public class SwtDatabindingProvider extends DefaultAutomaticDatabindingProvider 
 			importList.add(widgetDescriptor.getFullClassName());
 		}
 		// replace template patterns
-		code = StringUtils.replace(code, "%WidgetFields%", widgetFields.toString());
-		code = StringUtils.replace(code, "%Widgets%" + swtContainer + "%", widgets.toString());
+		code = code.replace("%WidgetFields%", widgetFields.toString());
+		code = code.replace("%Widgets%" + swtContainer + "%", widgets.toString());
 		//
-		code = StringUtils.replace(code, "%Observables%", observables.toString());
-		code = StringUtils.replace(code, "%Bindings%", bindings.toString());
+		code = code.replace("%Observables%", observables.toString());
+		code = code.replace("%Bindings%", bindings.toString());
 		// add imports
 		for (String qualifiedTypeName : importList) {
 			imports.addImport(qualifiedTypeName);

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp;singleton:=true
-Bundle-Version: 1.9.1200.qualifier
+Bundle-Version: 1.9.1300.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.rcp.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/RcpWizardPage.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/RcpWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,8 +18,6 @@ import org.eclipse.wb.internal.rcp.ToolkitProvider;
 
 import org.eclipse.swt.widgets.Composite;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * General wizard page for RCP wizard's.
  *
@@ -35,22 +33,19 @@ public class RcpWizardPage extends TemplateDesignWizardPage {
 	public static String doPerformSubstitutions(TemplateDesignWizardPage page,
 			String code,
 			ImportsManager imports) {
-		code = StringUtils.replace(code, "%CreateMethod%", page.getCreateMethod("createContents"));
-		code = StringUtils.replace(code, "%SWTLayout%", page.getLayoutCode("", imports));
-		code = StringUtils.replace(code, "%shell.SWTLayout%", page.getLayoutCode("shell.", imports));
+		code = code.replace("%CreateMethod%", page.getCreateMethod("createContents"));
+		code = code.replace("%SWTLayout%", page.getLayoutCode("", imports));
+		code = code.replace("%shell.SWTLayout%", page.getLayoutCode("shell.", imports));
 		code =
-				StringUtils.replace(
-						code,
+				code.replace(
 						"%container.SWTLayout%",
 						page.getLayoutCode("container.", imports));
 		code =
-				StringUtils.replace(
-						code,
+				code.replace(
 						"%field-prefix-shell.SWTLayout%",
 						page.getLayoutCode("%field-prefix%shell.", imports));
 		code =
-				StringUtils.replace(
-						code,
+				code.replace(
 						"%field-prefix-container.SWTLayout%",
 						page.getLayoutCode("%field-prefix%container.", imports));
 		code = performFieldPrefixesSubstitutions(code);

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/rcp/editor/EditorPartWizardPage.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/rcp/editor/EditorPartWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,8 +25,6 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.part.EditorPart;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.InputStream;
 
@@ -75,7 +73,7 @@ public final class EditorPartWizardPage extends RcpPartWizardPage {
 	@Override
 	protected String performSubstitutions(String code, ImportsManager imports) {
 		code = super.performSubstitutions(code, imports);
-		code = StringUtils.replace(code, "%EDITOR_ID%", m_newTypeClassName);
+		code = code.replace("%EDITOR_ID%", m_newTypeClassName);
 		return code;
 	}
 

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/rcp/editor/MultiPageEditorPartWizardPage.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/wizards/rcp/editor/MultiPageEditorPartWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -33,8 +33,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.part.MultiPageEditorPart;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.InputStream;
 import java.util.List;
 
@@ -64,7 +62,7 @@ public final class MultiPageEditorPartWizardPage extends RcpPartWizardPage {
 	@Override
 	protected String performSubstitutions(String code, ImportsManager imports) {
 		code = super.performSubstitutions(code, imports);
-		code = StringUtils.replace(code, "%EDITOR_ID%", m_newTypeClassName);
+		code = code.replace("%EDITOR_ID%", m_newTypeClassName);
 		return code;
 	}
 

--- a/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.databinding;singleton:=true
-Bundle-Version: 1.9.900.qualifier
+Bundle-Version: 1.9.1000.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/wizards/autobindings/SwingDatabindingProvider.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/wizards/autobindings/SwingDatabindingProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -183,12 +183,12 @@ public final class SwingDatabindingProvider extends DefaultAutomaticDatabindingP
 		String fieldPrefix = JavaCore.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES);
 		String fieldName = fieldPrefix + StringUtils.uncapitalize(beanClassShortName);
 		//
-		code = StringUtils.replace(code, "%BeanClass%", beanClassName);
+		code = code.replace("%BeanClass%", beanClassName);
 		//
 		if (ReflectionUtils.getConstructorBySignature(m_beanClass, "<init>()") == null) {
-			code = StringUtils.replace(code, "%BeanField%", fieldName);
+			code = code.replace("%BeanField%", fieldName);
 		} else {
-			code = StringUtils.replace(code, "%BeanField%", fieldName + " = new " + beanClassName + "()");
+			code = code.replace("%BeanField%", fieldName + " = new " + beanClassName + "()");
 		}
 		//
 		IPreferenceStore preferences = ToolkitProvider.DESCRIPTION.getPreferences();
@@ -196,8 +196,8 @@ public final class SwingDatabindingProvider extends DefaultAutomaticDatabindingP
 				preferences.getBoolean(FieldUniqueVariableSupport.P_PREFIX_THIS) ? "this." : "";
 		String beanFieldAccess = accessPrefix + fieldName;
 		//
-		code = StringUtils.replace(code, "%BeanName%", StringUtils.capitalize(beanClassShortName));
-		code = StringUtils.replace(code, "%BeanFieldAccess%", accessPrefix + fieldName);
+		code = code.replace("%BeanName%", StringUtils.capitalize(beanClassShortName));
+		code = code.replace("%BeanFieldAccess%", accessPrefix + fieldName);
 		// prepare properties
 		final List<PropertyAdapter> properties = new ArrayList<>();
 		Display.getDefault().syncExec(() -> CollectionUtils.addAll(properties, (PropertyAdapter[]) m_propertiesViewer.getCheckedElements()));
@@ -334,11 +334,11 @@ public final class SwingDatabindingProvider extends DefaultAutomaticDatabindingP
 			//
 		}
 		// replace template patterns
-		code = StringUtils.replace(code, "%ComponentFields%", componentFields.toString());
-		code = StringUtils.replace(code, "%Components%" + swingContainer + "%", components.toString());
-		code = StringUtils.replace(code, "%Bindings%", bindings.toString());
-		code = StringUtils.replace(code, "%Group%", group.toString());
-		code = StringUtils.replace(code, "%LAZY%", lazy.toString());
+		code = code.replace("%ComponentFields%", componentFields.toString());
+		code = code.replace("%Components%" + swingContainer + "%", components.toString());
+		code = code.replace("%Bindings%", bindings.toString());
+		code = code.replace("%Group%", group.toString());
+		code = code.replace("%LAZY%", lazy.toString());
 		// add imports
 		for (String qualifiedTypeName : importList) {
 			imports.addImport(qualifiedTypeName);

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/SwingWizardPage.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/wizards/SwingWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,8 +18,6 @@ import org.eclipse.wb.internal.swing.ToolkitProvider;
 
 import org.eclipse.swt.widgets.Composite;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * General wizard page for Swing wizard's.
  *
@@ -35,12 +33,8 @@ public class SwingWizardPage extends TemplateDesignWizardPage {
 	public static String doPerformSubstitutions(TemplateDesignWizardPage page,
 			String code,
 			ImportsManager imports) {
-		code = StringUtils.replace(code, "%SwingLayout%", page.getLayoutCode("", imports));
-		code =
-				StringUtils.replace(
-						code,
-						"%ContentPane.SwingLayout%",
-						page.getLayoutCode("getContentPane().", imports));
+		code = code.replace("%SwingLayout%", page.getLayoutCode("", imports));
+		code = code.replace("%ContentPane.SwingLayout%", page.getLayoutCode("getContentPane().", imports));
 		return code;
 	}
 


### PR DESCRIPTION
StringUtils is only used as a glorified null-check. Because those templates are not null, one can simply use String.replace().