### PR TITLE
EmbeddedSwingComposite must respect wHint and hHint

### DIFF
--- a/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
+++ b/org.eclipse.wb.swing/src/swingintegration/example/EmbeddedSwingComposite.java
@@ -220,7 +220,9 @@ public abstract class EmbeddedSwingComposite extends Composite {
 		}
 		// return size of Swing component
 		final java.awt.Dimension bounds = awtContext.bounds;
-		return new Point(bounds.width, bounds.height);
+		int width = SWT.DEFAULT != wHint ? wHint : bounds.width;
+		int height = SWT.DEFAULT != hHint ? hHint : bounds.height;
+		return new Point(width, height);
 	}
 
 	/**


### PR DESCRIPTION
If a non-default hint for the composite width and height is passed, it must be used over the preferred size of the Swing component.