### PR TITLE
Repair and execute disabled FormLayout tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleResizableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleResizableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,13 +17,10 @@ import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfo;
 import org.eclipse.wb.internal.swt.model.layout.form.FormLayoutInfoImplAutomatic;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.model.widgets.ControlInfo;
-import org.eclipse.wb.tests.designer.Expectations;
-import org.eclipse.wb.tests.designer.Expectations.IntValue;
 import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -47,7 +44,6 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 	 * Freely moving single resizable component with attachment into different target sides, attached
 	 * to component.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_leading_1_2component() throws Exception {
 		prepareComponent();
@@ -57,6 +53,7 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 						"  private Button button1;",
 						"  private Button button2;",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      button1 = new Button(this, SWT.NONE);",
@@ -86,6 +83,7 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 				"  private Button button1;",
 				"  private Button button2;",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      button1 = new Button(this, SWT.NONE);",
@@ -178,7 +176,6 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 	/**
 	 * Freely moving single resizable component with attachment into different target sides.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_leading_1() throws Exception {
 		prepareComponent();
@@ -187,6 +184,7 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 						"public class Test extends Shell {",
 						"  private Button button1;",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      button1 = new Button(this, SWT.NONE);",
@@ -206,6 +204,7 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 				"public class Test extends Shell {",
 				"  private Button button1;",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      button1 = new Button(this, SWT.NONE);",
@@ -223,7 +222,6 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 	/**
 	 * Freely moving single resizable component with attachment into reverse-different target sides.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_leading_2() throws Exception {
 		prepareComponent();
@@ -232,6 +230,7 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 						"public class Test extends Shell {",
 						"  private Button button1;",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      button1 = new Button(this, SWT.NONE);",
@@ -247,20 +246,13 @@ public class FormLayoutMoveSingleResizableTest extends RcpModelTest {
 		shell.refresh();
 		ControlInfo button1 = shell.getChildrenControls().get(0);
 		moveTo(shell, button1, 100, PlacementInfo.LEADING);
-		int expectedLeft =
-				Expectations.get(0, new IntValue[]{
-						new IntValue("scheglov-win", -334),
-						new IntValue("mitin-aa-mac", -350),
-						new IntValue("flanker-windows", -350),});
-		int expectedRight =
-				Expectations.get(0, new IntValue[]{
-						new IntValue("scheglov-win", 156),
-						new IntValue("mitin-aa-mac", 140),
-						new IntValue("flanker-windows", 140),});
+		int expectedLeft = -348;
+		int expectedRight = 142;
 		assertEditor(
 				"public class Test extends Shell {",
 				"  private Button button1;",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      button1 = new Button(this, SWT.NONE);",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithBothSidesTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithBothSidesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,6 @@ import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -306,7 +305,6 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 	/**
 	 * Freely moving single component in trailing with changing alignment.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_trailing_change_alignment() throws Exception {
 		prepareComponent();
@@ -314,6 +312,7 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 				parseComposite(
 						"public class Test extends Shell {",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      Button button = new Button(this, SWT.NONE);",
@@ -335,6 +334,7 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 		assertEditor(
 				"public class Test extends Shell {",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      Button button = new Button(this, SWT.NONE);",
@@ -395,7 +395,6 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 	/**
 	 * Freely moving single component in trailing without changing alignment.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_trailing_keep_alignment() throws Exception {
 		prepareComponent();
@@ -403,6 +402,7 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 				parseComposite(
 						"public class Test extends Shell {",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      Button button = new Button(this, SWT.NONE);",
@@ -424,6 +424,7 @@ public class FormLayoutMoveSingleWithBothSidesTest extends RcpModelTest {
 		assertEditor(
 				"public class Test extends Shell {",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      Button button = new Button(this, SWT.NONE);",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithSingleSideTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/FormLayoutMoveSingleWithSingleSideTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,6 @@ import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
 import org.eclipse.draw2d.geometry.Rectangle;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -395,7 +394,6 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 	/**
 	 * Freely moving single component in trailing with changing alignment.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_trailing_change_alignment() throws Exception {
 		prepareComponent();
@@ -403,6 +401,7 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 				parseComposite(
 						"public class Test extends Shell {",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      Button button = new Button(this, SWT.NONE);",
@@ -423,6 +422,7 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 		assertEditor(
 				"public class Test extends Shell {",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      Button button = new Button(this, SWT.NONE);",
@@ -480,7 +480,6 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 	/**
 	 * Freely moving single component in trailing without changing alignment.
 	 */
-	@Disabled
 	@Test
 	public void test_move_to_trailing_keep_alignment() throws Exception {
 		prepareComponent();
@@ -488,6 +487,7 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 				parseComposite(
 						"public class Test extends Shell {",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      Button button = new Button(this, SWT.NONE);",
@@ -508,6 +508,7 @@ public class FormLayoutMoveSingleWithSingleSideTest extends RcpModelTest {
 		assertEditor(
 				"public class Test extends Shell {",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    {",
 				"      Button button = new Button(this, SWT.NONE);",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/gef/FormLayoutAlignmentTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/gef/FormLayoutAlignmentTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -23,7 +23,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Shell;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -194,7 +193,6 @@ public class FormLayoutAlignmentTest extends RcpGefTest {
 	}
 
 	@Test
-	@Disabled
 	public void test_replicateWidth_leftRightAttached_reverse() throws Exception {
 		parse_twoButtons_typical(new String[]{
 				"left = new FormAttachment(0, 50);",
@@ -407,6 +405,7 @@ public class FormLayoutAlignmentTest extends RcpGefTest {
 						"  private Button button_1;",
 						"  private Button button_2;",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    {",
 						"      button_1 = new Button(this, SWT.NONE);",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/gef/FormLayoutMoveTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/layout/form/gef/FormLayoutMoveTest.java
@@ -49,12 +49,12 @@ public class FormLayoutMoveTest extends RcpGefTest {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Test
-	@Disabled
 	public void test_move_with_both_sides_attached() throws Exception {
 		CompositeInfo shell =
 				openComposite(
 						"public class Test extends Shell {",
 						"  public Test() {",
+						"    super(SWT.NONE);",
 						"    setLayout(new FormLayout());",
 						"    Button button = new Button(this, SWT.NONE);",
 						"    button.setText('New Button');",
@@ -70,6 +70,7 @@ public class FormLayoutMoveTest extends RcpGefTest {
 		assertEditor(
 				"public class Test extends Shell {",
 				"  public Test() {",
+				"    super(SWT.NONE);",
 				"    setLayout(new FormLayout());",
 				"    Button button = new Button(this, SWT.NONE);",
 				"    button.setText('New Button');",


### PR DESCRIPTION
Those tests depend on the insets of the SWT shell. Because these insets are OS-dependent, the used coordinates are also OS-dependent. To work around this problem, create the test shell with the SWT.NONE style.