### PR TITLE
Add 4.38-I-builds update site to target platform

### DIFF
--- a/target-platform/wb.target
+++ b/target-platform/wb.target
@@ -8,6 +8,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/staging/2025-12/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.38-I-builds/"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
This fixes ComponentEntryInfoTest.test_typeParameters_chooseType, which fails due to https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2505.