### PR TITLE
Don't run the dash-license tool on every build

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   check-dash-licenses:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'dash-license')
+    if: contains(github.event.pull_request.labels.*.name, 'dash-license')
     uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@1007e5ddce35a16b3b790f719ce8757ad6ec46ee # 1.1.0
     with:
       projectId: tools.windowbuilder


### PR DESCRIPTION
It is only intended to be used every now and then, primarily when there are actual changes to the target platform.