### PR TITLE
Synchronize update of Spinner dialog via CompletableFuture

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/AbstractSpinnerComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/AbstractSpinnerComposite.java
@@ -17,6 +17,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
@@ -54,10 +55,10 @@ abstract class AbstractSpinnerComposite extends Composite {
 	 * Sets the {@link SpinnerModelValue} to display/edit. <b>Important:</b> This
 	 * method is called from the AWT event dispatch thread.
 	 *
-	 * @return <code>true</code> if this {@link AbstractSpinnerComposite}
-	 *         understands given model.
+	 * @return {@link CompletableFuture} if this {@link AbstractSpinnerComposite}
+	 *         understands given model, otherwise {@code null}.
 	 */
-	public abstract boolean setModelValue(SpinnerModelValue modelValue);
+	public abstract CompletableFuture<Void> setModelValue(SpinnerModelValue modelValue);
 
 	/**
 	 * @return the error message, or <code>null</code> if model configured correctly.

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/DateSpinnerComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/DateSpinnerComposite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.models.spinner;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
@@ -32,6 +33,7 @@ import org.apache.commons.lang3.time.DateUtils;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
@@ -197,13 +199,14 @@ final class DateSpinnerComposite extends AbstractSpinnerComposite {
 	}
 
 	@Override
-	public boolean setModelValue(SpinnerModelValue modelValue) {
+	public CompletableFuture<Void> setModelValue(SpinnerModelValue modelValue) {
 		if (modelValue.getValue() instanceof javax.swing.SpinnerDateModel dateModel) {
 			Object value = dateModel.getValue();
 			Comparable<Date> start = dateModel.getStart();
 			Comparable<Date> end = dateModel.getEnd();
 			int calendarField = dateModel.getCalendarField();
-			getDisplay().asyncExec(() -> {
+			// OK, this is our model
+			return ExecutionUtils.runLogLater(() -> {
 				// values
 				setValue(m_valueField, value);
 				setValue(m_minField, start);
@@ -221,8 +224,6 @@ final class DateSpinnerComposite extends AbstractSpinnerComposite {
 				updateCheckField(m_maxButton, m_maxField, end != null);
 				m_modelDialog.validateAll();
 			});
-			// OK, this is our model
-			return true;
 		} else {
 			getDisplay().asyncExec(() -> {
 				// values
@@ -235,7 +236,7 @@ final class DateSpinnerComposite extends AbstractSpinnerComposite {
 				m_modelDialog.validateAll();
 			});
 			// no, we don't know this model
-			return false;
+			return null;
 		}
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/ListSpinnerComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/ListSpinnerComposite.java
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.swing.model.property.editor.models.spinner;
 
 import org.eclipse.wb.internal.core.model.property.converter.StringArrayConverter;
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
@@ -26,6 +27,7 @@ import org.eclipse.swt.widgets.Text;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
@@ -75,17 +77,16 @@ final class ListSpinnerComposite extends AbstractSpinnerComposite {
 	}
 
 	@Override
-	public boolean setModelValue(SpinnerModelValue modelValue) {
+	public CompletableFuture<Void> setModelValue(SpinnerModelValue modelValue) {
 		if (modelValue.getValue() instanceof javax.swing.SpinnerListModel listModel) {
 			String text = StringUtils.join(listModel.getList().iterator(), "\n");
-			getDisplay().asyncExec(() -> {
+			// OK, this is our model
+			return ExecutionUtils.runLogLater(() -> {
 				m_textWidget.setText(text);
 				m_modelDialog.validateAll();
 			});
-			// OK, this is our model
-			return true;
 		}
-		return false;
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/NumberSpinnerComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/NumberSpinnerComposite.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.models.spinner;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
@@ -27,6 +28,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Spinner;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
@@ -170,13 +172,14 @@ final class NumberSpinnerComposite extends AbstractSpinnerComposite {
 	}
 
 	@Override
-	public boolean setModelValue(SpinnerModelValue modelValue) {
+	public CompletableFuture<Void> setModelValue(SpinnerModelValue modelValue) {
 		if (modelValue.getValue() instanceof javax.swing.SpinnerNumberModel numberModel) {
 			Object value = numberModel.getValue();
 			Comparable<?> minimum = numberModel.getMinimum();
 			Comparable<?> maximum = numberModel.getMaximum();
 			Number stepSize = numberModel.getStepSize();
-			getDisplay().asyncExec(() -> {
+			// OK, this is our model
+			return ExecutionUtils.runLogLater(() -> {
 				// type
 				NumberTypeDescription[] values = NumberTypeDescription.values();
 				for (int i = 0; i < values.length; i++) {
@@ -195,8 +198,6 @@ final class NumberSpinnerComposite extends AbstractSpinnerComposite {
 				updateCheckSpinner(m_maxButton, m_maxField, maximum != null);
 				m_modelDialog.validateAll();
 			});
-			// OK, this is our model
-			return true;
 		} else {
 			// disable min/max fields
 			getDisplay().asyncExec(() -> {
@@ -204,7 +205,7 @@ final class NumberSpinnerComposite extends AbstractSpinnerComposite {
 				updateCheckSpinner(m_maxButton, m_maxField, false);
 				m_modelDialog.validateAll();
 			});
-			return false;
+			return null;
 		}
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/SpinnerModelDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/spinner/SpinnerModelDialog.java
@@ -28,13 +28,13 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The dialog for editing {@link javax.swing.SpinnerModel SpinnerModel}.
@@ -102,7 +102,6 @@ public final class SpinnerModelDialog extends AbstractValidationTitleAreaDialog 
 			m_composites.add(new DateSpinnerComposite(m_tabFolder, this));
 		}
 		// create tab for each spinner composite
-		Display display = getShell().getDisplay();
 		for (AbstractSpinnerComposite composite : m_composites) {
 			// create tab
 			CTabItem tabItem = new CTabItem(m_tabFolder, SWT.NONE);
@@ -110,8 +109,9 @@ public final class SpinnerModelDialog extends AbstractValidationTitleAreaDialog 
 			tabItem.setText(composite.getTitle());
 			// select tab
 			SwingUtils.runLogLater(() -> {
-				if (composite.setModelValue(m_modelValue)) {
-					display.asyncExec(() -> m_tabFolder.setSelection(tabItem));
+				CompletableFuture<Void> result = composite.setModelValue(m_modelValue);
+				if (result != null) {
+					result.thenAccept(ignore -> m_tabFolder.setSelection(tabItem));
 				}
 			});
 		}


### PR DESCRIPTION
The dialog should be updated once the Swing composite has been created. Given that this is done asynchronously, we need to use the thenAccept() method of the CompletableFuture, to make sure that the SWT UI thread is only executed once everything is ready.