### PR TITLE
Remove deprecated StringUtils.removeStart()

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -197,7 +197,7 @@ public final class FlowContainerFactory {
 	}
 
 	private static AssociationObjectFactory getAssociation_invocationChild(String associationString) {
-		associationString = StringUtils.removeStart(associationString, "invocationChild ");
+		associationString = associationString.replaceFirst("^invocationChild ", "");
 		Assert.isTrue(
 				associationString.startsWith("%parent%."),
 				"Association 'invocationChild' should start with %%parent%%., but '%s' found.",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/SimpleContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/SimpleContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -139,7 +139,7 @@ public final class SimpleContainerFactory {
 	}
 
 	private static AssociationObjectFactory getAssociation_invocationChild(String associationString) {
-		associationString = StringUtils.removeStart(associationString, "invocationChild ");
+		associationString = associationString.replaceFirst("^invocationChild ", "");
 		Assert.isTrue(
 				associationString.startsWith("%parent%."),
 				"Association 'invocationChild' should start with '%%parent%%.', but '%s' found.",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -92,7 +92,7 @@ final class ListenerInfo {
 	private static String _getListenerSimpleName(Method addListenerMethod) {
 		String name = addListenerMethod.getName();
 		// convert into simple name
-		name = StringUtils.removeStart(name, "add");
+		name = name.replaceFirst("^add", "");
 		name = StringUtils.removeEnd(name, "Listener");
 		name = StringUtils.removeEnd(name, "Handler");
 		name = StringUtils.uncapitalize(name);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -51,13 +51,13 @@ public abstract class CopyPropertyTopAbstractSupport {
 				String[] parts = StringUtils.split(parameter);
 				for (String part : parts) {
 					if (part.startsWith("from=")) {
-						sourcePath = StringUtils.removeStart(part, "from=");
+						sourcePath = part.substring("from=".length());
 					}
 					if (part.startsWith("to=")) {
-						copyTitle = StringUtils.removeStart(part, "to=");
+						copyTitle = part.substring("to=".length());
 					}
 					if (part.startsWith("category=")) {
-						String categoryText = StringUtils.removeStart(part, "category=");
+						String categoryText = part.substring("category=".length());
 						category = PropertyCategory.get(categoryText, category);
 					}
 				}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -133,27 +133,27 @@ abstract class ModelMethodPropertyAbstractSupport {
 		////////////////////////////////////////////////////////////////////////////
 		protected void processParameterPart(String part) throws Exception {
 			if (part.startsWith("getter=")) {
-				getterSignature = StringUtils.removeStart(part, "getter=");
+				getterSignature = part.substring("getter=".length());
 			}
 			if (part.startsWith("setter=")) {
-				setterSignature = StringUtils.removeStart(part, "setter=");
+				setterSignature = part.substring("setter=".length());
 			}
 			if (part.startsWith("type=")) {
-				String typeName = StringUtils.removeStart(part, "type=");
+				String typeName = part.substring("type=".length());
 				type = ReflectionUtils.getClassByName(GlobalState.getClassLoader(), typeName);
 				if (propertyEditor == null) {
 					propertyEditor = GlobalState.getDescriptionHelper().getEditorForType(type);
 				}
 			}
 			if (part.startsWith("editor=")) {
-				String desc = StringUtils.removeStart(part, "editor=");
+				String desc = part.substring("editor=".length());
 				parseEditor(desc);
 			}
 			if (part.startsWith("title=")) {
-				title = StringUtils.removeStart(part, "title=");
+				title = part.substring("title=".length());
 			}
 			if (part.startsWith("category=")) {
-				String categoryText = StringUtils.removeStart(part, "category=");
+				String categoryText = part.substring("category=".length());
 				category = PropertyCategory.get(categoryText, category);
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyChildSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyChildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,8 +14,6 @@ package org.eclipse.wb.internal.core.model.util.generic;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * This helper allows to create top-level {@link Property} that as wrapper for some
@@ -60,7 +58,7 @@ public final class ModelMethodPropertyChildSupport extends ModelMethodPropertyAb
 			protected void processParameterPart(String part) throws Exception {
 				super.processParameterPart(part);
 				if (part.startsWith("child=")) {
-					m_childTypeName = StringUtils.removeStart(part, "child=");
+					m_childTypeName = part.substring("child=".length());
 				}
 			}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -185,7 +185,7 @@ public class CodeUtils {
 		String tag = preferences.getString(name);
 		tag = tag.trim();
 		// remove leading "//" prefix to search even "// $hide" - formatted line comments
-		tag = StringUtils.removeStart(tag, "//");
+		tag = tag.replaceFirst("^//", "");
 		return tag;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/ProjectReportEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/ProjectReportEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,6 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.InputStream;
@@ -78,9 +77,11 @@ public final class ProjectReportEntry implements IReportEntry {
 					IFile file = (IFile) resource;
 					InputStream fileStream = file.getContents();
 					// remove leading slash
-					String filePath =
-							"project/"
-									+ StringUtils.removeStart(file.getFullPath().toPortableString(), File.separator);
+					String filePath = file.getFullPath().toPortableString();
+					if (filePath.startsWith(File.separator)) {
+						filePath = filePath.substring(File.separator.length());
+					}
+					filePath = "project/" + filePath;
 					zipStream.putNextEntry(new ZipEntry(filePath));
 					try {
 						IOUtils.copy(fileStream, zipStream);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
@@ -110,7 +110,7 @@ public final class PropertyCategory {
 		// system
 		if (StringUtils.startsWith(text, "system(")) {
 			String systemText = text;
-			systemText = StringUtils.removeStart(systemText, "system(");
+			systemText = systemText.substring("system(".length());
 			systemText = StringUtils.removeEnd(systemText, ")");
 			try {
 				int priority = Integer.parseInt(systemText);

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
@@ -197,8 +197,11 @@ public class ControllerSupport {
 		String reference = JavaInfoReferenceProvider.getReference(javaInfo);
 		String fieldPrefix = JavaCore.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES);
 		fieldPrefix = fieldPrefix == null ? "m_" : fieldPrefix;
-		String methodName =
-				"get" + StringUtils.capitalize(StringUtils.removeStart(reference, fieldPrefix)) + "()";
+		String methodName = reference;
+		if (methodName.startsWith(fieldPrefix)) {
+			methodName = methodName.substring(fieldPrefix.length());
+		}
+		methodName = "get" + StringUtils.capitalize(methodName) + "()";
 		// prepare method header
 		String header =
 				"public " + javaInfo.getDescription().getComponentClass().getName() + " " + methodName;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -120,7 +120,7 @@ public class BeanBindableInfo extends BindableInfo {
 				}
 			}
 		} else {
-			String localReference = StringUtils.removeStart(reference, "\"");
+			String localReference = reference.replaceFirst("^\"", "");
 			localReference = StringUtils.removeEnd(localReference, "\"");
 			return resolvePropertyReference(reference, StringUtils.split(localReference, "."), 0);
 		}
@@ -140,7 +140,7 @@ public class BeanBindableInfo extends BindableInfo {
 			String localReference = references[index];
 			//
 			for (PropertyBindableInfo property : getProperties()) {
-				String propertyReference = StringUtils.removeStart(property.getReference(), "\"");
+				String propertyReference = property.getReference().replaceFirst("^\"", "");
 				propertyReference = StringUtils.removeEnd(propertyReference, "\"");
 				int pointIndex = propertyReference.lastIndexOf('.');
 				//

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,7 +58,7 @@ public final class BeanPropertyDescriptorBindableInfo extends BeanPropertyBindab
 			String reference,
 			Class<?> objectType) throws Exception {
 		if (parent instanceof BeanPropertyDescriptorBindableInfo bindableParent) {
-			String parentReference = StringUtils.removeStart(bindableParent.getReference(), "\"");
+			String parentReference = bindableParent.getReference().replaceFirst("^\"", "");
 			parentReference = StringUtils.removeEnd(parentReference, "\"");
 			//
 			final String bindingReference = parentReference + "." + reference;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingRewriteProcessor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingRewriteProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,8 +28,6 @@ import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Changes known unsupported patterns into supported.
@@ -96,7 +94,7 @@ public final class SwingRewriteProcessor {
 						"java.awt.Container",
 						"setLayout(java.awt.LayoutManager)")) {
 					String superSource = editor.getSource(node);
-					String source = StringUtils.removeStart(superSource, "super.");
+					String source = superSource.replaceFirst("^super\\.", "");
 					editor.replaceExpression(node, source);
 				}
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
@@ -99,7 +99,9 @@ public class Replacer {
 					System.exit(0);
 				}
 				// begin/end
-				invocation = StringUtils.removeStart(invocation, begin);
+				if (invocation.startsWith(begin)) {
+					invocation = invocation.substring(begin.length());
+				}
 				invocation = StringUtils.removeEnd(invocation, end);
 				//invocation = "createTypeDeclaration_Test0(" + invocation + "\")";
 				invocation = "createTypeDeclaration_Test0(" + invocation;


### PR DESCRIPTION
Use String.substring() using the length of the string to remove. Note that this requires an additional check to make sure the string actually starts with the given sequence.