### PR TITLE
Avoid creating a static shell for the BorderDialog

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,6 +25,7 @@ import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.core.utils.ui.dialogs.ResizableDialog;
 import org.eclipse.wb.internal.swing.Activator;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
+import org.eclipse.wb.internal.swing.model.property.editor.border.fields.BorderField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.pages.AbstractBorderComposite;
 import org.eclipse.wb.internal.swing.model.property.editor.border.pages.BevelBorderComposite;
 import org.eclipse.wb.internal.swing.model.property.editor.border.pages.CompoundBorderComposite;
@@ -71,6 +72,7 @@ public final class BorderDialog extends ResizableDialog {
 	private boolean m_borderModified;
 	private Border m_border;
 	private String m_source;
+	private Shell m_tmpShell;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -118,6 +120,18 @@ public final class BorderDialog extends ResizableDialog {
 	 */
 	public String getBorderSource() {
 		return m_source;
+	}
+
+	/**
+	 * Creates and returns an invisible shell that may be used by all
+	 * {@link BorderField}s within this dialog. This shell only exists while the
+	 * dialog is open.
+	 */
+	public Shell getTemporaryShell() {
+		if (m_tmpShell == null) {
+			m_tmpShell = new Shell(getShell());
+		}
+		return m_tmpShell;
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BorderField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BorderField.java
@@ -48,7 +48,7 @@ public final class BorderField extends AbstractBorderField {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public BorderField(Composite parent, String labelText, String buttonText) {
+	public BorderField(AbstractBorderComposite parent, String labelText, String buttonText) {
 		super(parent, 2, labelText);
 		{
 			m_text = new Text(this, SWT.BORDER | SWT.READ_ONLY);
@@ -121,13 +121,17 @@ public final class BorderField extends AbstractBorderField {
 		return null;
 	}
 
+	@Override
+	public AbstractBorderComposite getParent() {
+		return (AbstractBorderComposite) super.getParent();
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Borders
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private static final Shell INVISIBLE_SHELL = new Shell();
-	private static final List<AbstractBorderComposite> m_borderComposites = new LinkedList<>();
+	private final List<AbstractBorderComposite> m_borderComposites = new LinkedList<>();
 
 	/**
 	 * Note, that we can not reuse {@link AbstractBorderComposite}'s, so when we get some
@@ -135,7 +139,7 @@ public final class BorderField extends AbstractBorderField {
 	 *
 	 * @return the instance free of {@link AbstractBorderComposite}.
 	 */
-	private static final AbstractBorderComposite getBorderComposite(Class<?> compositeClass)
+	private final AbstractBorderComposite getBorderComposite(Class<?> compositeClass)
 			throws Exception {
 		for (Iterator<AbstractBorderComposite> I = m_borderComposites.iterator(); I.hasNext();) {
 			AbstractBorderComposite borderComposite = I.next();
@@ -145,14 +149,14 @@ public final class BorderField extends AbstractBorderField {
 			}
 		}
 		// create new instance
-		return (AbstractBorderComposite) compositeClass.getConstructor(Composite.class).newInstance(
-				INVISIBLE_SHELL);
+		Shell shell = getParent().getDialog().getTemporaryShell();
+		return (AbstractBorderComposite) compositeClass.getConstructor(Composite.class).newInstance(shell);
 	}
 
 	/**
 	 * Returns given {@link AbstractBorderComposite} to the list of available.
 	 */
-	private static final void returnBorderComposite(AbstractBorderComposite borderComposite) {
+	private final void returnBorderComposite(AbstractBorderComposite borderComposite) {
 		m_borderComposites.add(borderComposite);
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
@@ -106,6 +106,13 @@ public abstract class AbstractBorderComposite extends Composite {
 		return null;
 	}
 
+	/**
+	 * Returns the {@link BorderDialog} containing this composite.
+	 */
+	public BorderDialog getDialog() {
+		return m_borderDialog;
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Components


### PR DESCRIPTION
When the BorderDialog is opened for the first time, an invisible Shell is created, which is required for the source code generation. This Shell is never disposed. This invisible shell is now created as a child of the dialog.