### PR TITLE
Store generated Java code for BorderField in a local variable

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BorderField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/BorderField.java
@@ -42,6 +42,7 @@ public final class BorderField extends AbstractBorderField {
 	private AstEditor m_editor;
 	private Text m_text;
 	private Border m_border;
+	private String m_source;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -66,6 +67,7 @@ public final class BorderField extends AbstractBorderField {
 					borderDialog.setBorder(m_border);
 					if (borderDialog.open() == Window.OK) {
 						m_border = borderDialog.getBorder();
+						m_source = borderDialog.getBorderSource();
 						showBorder();
 						notifyListeners(SWT.Selection, new Event());
 					}
@@ -98,11 +100,16 @@ public final class BorderField extends AbstractBorderField {
 	 */
 	public void setBorder(Border border) throws Exception {
 		m_border = border;
+		m_source = calculateSource();
 		showBorder();
 	}
 
 	@Override
-	public String getSource() throws Exception {
+	public String getSource() {
+		return m_source;
+	}
+	
+	private String calculateSource() throws Exception{
 		// try to use AbstractBorderComposite's to convert Border into source
 		if (m_border != null) {
 			Class<?> compositeClass = AbstractBorderComposite.getCompositeClass(m_border.getClass());


### PR DESCRIPTION
Rather than calculating the source code whenever getSource() is called, it should be calculated when the internal BorderDialog is closed or when the border field is updated. This avoids timing issues where the border field hasn't been updated by the time the method is called.