### PR TITLE
Correct behavior when a Border is managed by multiple BorderComposites

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
@@ -103,6 +103,12 @@ public abstract class AbstractBorderComposite extends Composite {
 				return entry.getKey();
 			}
 		}
+		// The generic Swing borders might be of the same type as one that is managed by
+		// one of the other composite classes. It must therefore be given the lowest
+		// priority.
+		if (SwingBorderComposite.contains(clazz)) {
+			return SwingBorderComposite.class;
+		}
 		return null;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
@@ -22,6 +22,7 @@ import java.awt.Insets;
 
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.MatteBorder;
 
 /**
  * Implementation of {@link AbstractBorderComposite} that sets {@link EmptyBorder}.
@@ -56,7 +57,17 @@ public final class EmptyBorderComposite extends AbstractBorderComposite {
 
 	static {
 		// Check for identity because EmptyBorder is sub-classed by MatteBorder
-		COMPOSITE_CLASSES.put(EmptyBorderComposite.class, EmptyBorder.class::equals);
+		COMPOSITE_CLASSES.put(EmptyBorderComposite.class, EmptyBorderComposite::contains);
+	}
+
+	/**
+	 * @return {@code true}, if this composite can manage the given border.
+	 */
+	private static boolean contains(Class<?> border) {
+		if (MatteBorder.class.isAssignableFrom(border)) {
+			return false;
+		}
+		return EmptyBorder.class.isAssignableFrom(border);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SwingBorderComposite.java
@@ -69,10 +69,6 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 		m_bordersList.deselectAll();
 	}
 
-	static {
-		COMPOSITE_CLASSES.put(SwingBorderComposite.class, SwingBorderComposite::contains);
-	}
-
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Access
@@ -126,7 +122,7 @@ public final class SwingBorderComposite extends AbstractBorderComposite {
 	/**
 	 * @return {@code true}, if this composite can manage the given border.
 	 */
-	private static boolean contains(Class<?> border) {
+	/* package */ static boolean contains(Class<?> border) {
 		return m_borders.stream().map(Border::getClass).anyMatch(border::equals);
 	}
 


### PR DESCRIPTION
This is a follow-up to the lookup table that was introduced with870f5bdfbf1c90e31288fe1723e839532497a5f8. In some cases it might happen that the SwingBorderComposite is used to manage classes that should be managed by one of the other composites (e.g. EmptyBorder).

Because a simple HashMap is used, we can't guarantee that the SwingBorderComposite is checked last. Because of this, it must not be considered when iterating over the elements in this map and instead be explicitly checked afterwards.

Additionally, the check in the EmptyBorderComposite has been extended to allow subclasses of the EmptyBorder, as long as it's not a subclass of the MatteBorder, which is managed by the MatteBorderComposite.