### PR TITLE
Fix NPE when restoring layout to default value

### DIFF
--- a/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.ui;singleton:=true
-Bundle-Version: 1.10.800.qualifier
+Bundle-Version: 1.10.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/preferences/LayoutsPreferencePage.java
+++ b/org.eclipse.wb.core.ui/src/org/eclipse/wb/internal/core/preferences/LayoutsPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -193,7 +193,7 @@ public abstract class LayoutsPreferencePage extends AbstractBindingPreferencesPa
 							return layout.getId();
 					}
 						// implicit layout
-						return null;
+						return "";
 					}
 				}, new StringPreferenceProvider(m_preferences, IPreferenceConstants.P_LAYOUT_DEFAULT), true);
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
@@ -175,6 +175,7 @@ public class ModelMessages extends NLS {
 	public static String LafSelectionItem_noDesignPage;
 	public static String LafSelectionItem_select;
 	public static String LafSupport_errCanParse_setLookAndFeel;
+	public static String LayoutInfo_unknownDefaultLayout;
 	public static String LineBorderComposite_color;
 	public static String LineBorderComposite_corners;
 	public static String LineBorderComposite_cornersRounded;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.properties
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.properties
@@ -169,6 +169,7 @@ LafSelectionItem_addMore=Add more...
 LafSelectionItem_noDesignPage=No design page site for {0}
 LafSelectionItem_select=Select Look-n-Feel
 LafSupport_errCanParse_setLookAndFeel=Can't determine LookAndFeel class in UIManager.setLookAndFeel() invocation.
+LayoutInfo_unknownDefaultLayout=No layout found with description: {0}; Old layout has been removed.
 LineBorderComposite_color=&Color:
 LineBorderComposite_corners=C&orners:
 LineBorderComposite_cornersRounded=&rounded

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/LayoutManagersTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/LayoutManagersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,7 +39,6 @@ import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
 import org.eclipse.wb.tests.designer.swing.SwingTestUtils;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.awt.BorderLayout;
@@ -605,7 +604,6 @@ public class LayoutManagersTest extends AbstractLayoutTest {
 	/**
 	 * Delete using "Layout" property.
 	 */
-	@Disabled
 	@Test
 	public void test_delete2() throws Exception {
 		ContainerInfo panel =


### PR DESCRIPTION
The changes introduced with 7ff0657587397a86147015cd37cd19dd51afac6e cause an exception, if no layout is set. Instead of an empty string, the "null" string is used to describe the implict layout. This breaks the selection on the preference page.

If no layout with this id is found, the call to setDefaultLayout() fails with a NullPointerException, which is the case for the default selection or if a layout no longer exists.

Using the GridLayout as an implicit layout is also not the correct behavior. If this is the desired behavior, the GridLayout must be selected in the preference page.