### PR TITLE
Implement the "setDefaultLayout()" method for SWT

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/layout/AbstractLayoutInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/layout/AbstractLayoutInfo.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.internal.core.model.layout;
+
+import org.eclipse.wb.core.model.JavaInfo;
+import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.editor.Messages;
+import org.eclipse.wb.internal.core.model.JavaInfoUtils;
+import org.eclipse.wb.internal.core.model.creation.ConstructorCreationSupport;
+import org.eclipse.wb.internal.core.model.creation.CreationSupport;
+import org.eclipse.wb.internal.core.model.description.ComponentDescription;
+import org.eclipse.wb.internal.core.model.description.LayoutDescription;
+import org.eclipse.wb.internal.core.model.description.helpers.LayoutDescriptionHelper;
+import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
+import org.eclipse.wb.internal.core.utils.ast.AstEditor;
+import org.eclipse.wb.internal.core.utils.state.EditorState;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.osgi.util.NLS;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Common base class for editing the {@code layout} of a UI container.
+ *
+ * @param <T> The UI container. Either an SWT {@code Composite} or Swing
+ *            {@code Container}.
+ */
+public abstract class AbstractLayoutInfo<T extends JavaInfo> extends JavaInfo {
+
+	public AbstractLayoutInfo(AstEditor editor, ComponentDescription description, CreationSupport creationSupport)
+			throws Exception {
+		super(editor, description, creationSupport);
+	}
+
+	/**
+	 * Removes the previous layout and sets the default layout as specified in the
+	 * {@link LayoutsPreferencePage}.
+	 */
+	protected void setDefaultLayout() throws Exception {
+		IPreferenceStore prefs = getDescription().getToolkit().getPreferences();
+		String defaultValue = prefs.getString(IPreferenceConstants.P_LAYOUT_DEFAULT);
+		if (defaultValue.isEmpty()) {
+			delete();
+			return;
+		}
+		List<LayoutDescription> descriptions = LayoutDescriptionHelper.get(getDescription().getToolkit());
+		String creationId = null;
+		ClassLoader editorLoader = null;
+		Class<?> layoutClass = null;
+		for (LayoutDescription description : descriptions) {
+			if (Objects.equals(defaultValue, description.getId())) {
+				creationId = description.getCreationId();
+				editorLoader = EditorState.get(getParentJava().getEditor()).getEditorLoader();
+				layoutClass = editorLoader.loadClass(description.getLayoutClassName());
+			}
+		}
+		if (layoutClass == null) {
+			DesignerPlugin.log(NLS.bind(Messages.AbstractLayoutInfo_unknownDefaultLayout, defaultValue));
+			delete();
+			return;
+		}
+		@SuppressWarnings("unchecked")
+		T defaultLayoutInfo = (T) JavaInfoUtils.createJavaInfo(getParentJava().getEditor(), layoutClass,
+				new ConstructorCreationSupport(creationId, true));
+		setLayout(defaultLayoutInfo);
+	}
+
+	/**
+	 * Sets new {@code LayoutInfo}.
+	 */
+	protected abstract void setLayout(T layoutInfo) throws Exception;
+}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/Messages.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.wb.internal.core.editor;
 import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
+	public static String AbstractLayoutInfo_unknownDefaultLayout;
 	public static String BadNodesErrorPage_nodeGroup;
 	public static String BadNodesErrorPage_nodesGroup;
 	public static String BadNodesParserErrorPage_title;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/messages.properties
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/messages.properties
@@ -5,6 +5,7 @@ SelectionToolEntryInfo_name=Selection
 TabOrderToolEntryInfo_description=Set tab order for selected container.
 TabOrderToolEntryInfo_name=Tab Order
 
+AbstractLayoutInfo_unknownDefaultLayout=No layout found with description: {0}; Old layout has been removed.
 BadNodesErrorPage_nodeGroup=Full node source and exception
 BadNodesErrorPage_nodesGroup=Nodes caused exceptions
 BadNodesParserErrorPage_title=Parser errors

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.java
@@ -175,7 +175,6 @@ public class ModelMessages extends NLS {
 	public static String LafSelectionItem_noDesignPage;
 	public static String LafSelectionItem_select;
 	public static String LafSupport_errCanParse_setLookAndFeel;
-	public static String LayoutInfo_unknownDefaultLayout;
 	public static String LineBorderComposite_color;
 	public static String LineBorderComposite_corners;
 	public static String LineBorderComposite_cornersRounded;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.properties
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/ModelMessages.properties
@@ -169,7 +169,6 @@ LafSelectionItem_addMore=Add more...
 LafSelectionItem_noDesignPage=No design page site for {0}
 LafSelectionItem_select=Select Look-n-Feel
 LafSupport_errCanParse_setLookAndFeel=Can't determine LookAndFeel class in UIManager.setLookAndFeel() invocation.
-LayoutInfo_unknownDefaultLayout=No layout found with description: {0}; Old layout has been removed.
 LineBorderComposite_color=&Color:
 LineBorderComposite_corners=C&orners:
 LineBorderComposite_cornersRounded=&rounded

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutInfo.java
@@ -29,6 +29,7 @@ import org.eclipse.wb.internal.core.model.clipboard.ClipboardCommand;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.creation.IImplicitCreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
+import org.eclipse.wb.internal.core.model.layout.AbstractLayoutInfo;
 import org.eclipse.wb.internal.core.model.presentation.IObjectPresentation;
 import org.eclipse.wb.internal.core.model.property.ComplexProperty;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -64,7 +65,7 @@ import java.util.List;
  * @author lobas_av
  * @coverage swt.model.layout
  */
-public class LayoutInfo extends JavaInfo implements ILayoutInfo<ControlInfo> {
+public class LayoutInfo extends AbstractLayoutInfo<LayoutInfo> implements ILayoutInfo<ControlInfo> {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
@@ -377,7 +378,7 @@ public class LayoutInfo extends JavaInfo implements ILayoutInfo<ControlInfo> {
 					@Override
 					public void setValue(Object value) throws Exception {
 						if (value == UNKNOWN_VALUE) {
-							delete();
+							setDefaultLayout();
 						}
 					}
 				};
@@ -694,5 +695,10 @@ public class LayoutInfo extends JavaInfo implements ILayoutInfo<ControlInfo> {
 	 * Store general layout data properties for {@link ControlInfo}.
 	 */
 	protected void storeLayoutData(ControlInfo control, LayoutDataInfo layoutData) throws Exception {
+	}
+
+	@Override
+	protected void setLayout(LayoutInfo layoutInfo) throws Exception {
+		getComposite().setLayout(layoutInfo);
 	}
 }


### PR DESCRIPTION
This moves the setDefaultLayout() method that is currently only used in Swing to a common base class, which is implemented by both the SWT and the Swing LayoutInfo.