### PR TITLE
Move processing of Swing border to AWT event dispatcher thread

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderValue.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderValue.java
@@ -60,8 +60,7 @@ public final class BorderValue extends AbstractObservableValue<Border> {
 	}
 
 	@Override
-	public Border doGetValue() {
-		// TODO Make protected
+	protected Border doGetValue() {
 		return border;
 	}
 

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/AbstractBorderField.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/fields/AbstractBorderField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -53,5 +53,5 @@ public abstract class AbstractBorderField extends Composite {
 	/**
 	 * @return the source corresponding to the made selection.
 	 */
-	public abstract String getSource() throws Exception;
+	public abstract String getSource();
 }

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/AbstractBorderComposite.java
@@ -14,6 +14,7 @@ package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.swing.model.property.editor.border.BorderDialog;
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.AbstractBorderField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.BooleanField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.BorderField;
@@ -30,6 +31,7 @@ import org.eclipse.swt.widgets.Listener;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import javax.swing.border.Border;
@@ -75,17 +77,17 @@ public abstract class AbstractBorderComposite extends Composite {
 	}
 
 	/**
-	 * Sets the {@link Border} to edit.
+	 * Sets the {@link BorderValue} to edit.
 	 *
-	 * @return <code>true</code> if this {@link AbstractBorderComposite} understands given
-	 *         {@link Border}.
+	 * @return A {@link CompletableFuture} if this {@link AbstractBorderComposite}
+	 *         understands given {@link BorderValue}, otherwise {@code null}.
 	 */
-	public abstract boolean setBorder(Border border) throws Exception;
+	public abstract CompletableFuture<Void> setBorderValue(BorderValue borderValue);
 
 	/**
 	 * @return the source for updated {@link Border}.
 	 */
-	public abstract String getSource() throws Exception;
+	public abstract String getSource();
 
 	/**
 	 * Used by the {@link BorderField} for the source code generation.

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/BevelBorderComposite.java
@@ -15,13 +15,18 @@ package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.RadioField;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.widgets.Composite;
 
+import java.awt.Color;
+import java.util.concurrent.CompletableFuture;
+
+import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
-import javax.swing.border.Border;
 
 /**
  * Implementation of {@link AbstractBorderComposite} that sets {@link BevelBorder}.
@@ -72,19 +77,25 @@ public final class BevelBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		if (border instanceof BevelBorder ourBorder) {
-			m_typeField.setValue(ourBorder.getBevelType());
-			m_highlightOuterField.setValue(ourBorder.getHighlightOuterColor());
-			m_highlightInnerField.setValue(ourBorder.getHighlightInnerColor());
-			m_shadowOuterField.setValue(ourBorder.getShadowOuterColor());
-			m_shadowInnerField.setValue(ourBorder.getShadowInnerColor());
+	public CompletableFuture<Void> setBorderValue(BorderValue borderValue) {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatcher thread");
+		if (borderValue.getValue() instanceof BevelBorder ourBorder) {
+			int bevelType = ourBorder.getBevelType();
+			Color highlightOuterColor = ourBorder.getHighlightOuterColor();
+			Color highlightInnerColor = ourBorder.getHighlightInnerColor();
+			Color shadowOuterColor = ourBorder.getShadowOuterColor();
+			Color shadowInnerColor = ourBorder.getShadowInnerColor();
 			// OK, this is our Border
-			return true;
-		} else {
-			// no, we don't know this Border
-			return false;
+			return ExecutionUtils.runLogLater(() -> {
+				m_typeField.setValue(bevelType);
+				m_highlightOuterField.setValue(highlightOuterColor);
+				m_highlightInnerField.setValue(highlightInnerColor);
+				m_shadowOuterField.setValue(shadowOuterColor);
+				m_shadowInnerField.setValue(shadowInnerColor);
+			});
 		}
+		// no, we don't know this Border
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/DefaultBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/DefaultBorderComposite.java
@@ -12,7 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
+
 import org.eclipse.swt.widgets.Composite;
+
+import java.util.concurrent.CompletableFuture;
 
 import javax.swing.JComponent;
 import javax.swing.border.Border;
@@ -41,8 +45,8 @@ public final class DefaultBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		return false;
+	public CompletableFuture<Void> setBorderValue(BorderValue border) {
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EmptyBorderComposite.java
@@ -12,15 +12,19 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.IntegerField;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.widgets.Composite;
 
 import java.awt.Insets;
+import java.util.concurrent.CompletableFuture;
 
-import javax.swing.border.Border;
+import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 
@@ -76,20 +80,21 @@ public final class EmptyBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		if (border != null && border.getClass() == EmptyBorder.class) {
-			EmptyBorder ourBorder = (EmptyBorder) border;
+	public CompletableFuture<Void> setBorderValue(BorderValue borderValue) {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatcher thread");
+		if (borderValue.getValue() != null && borderValue.getValue().getClass() == EmptyBorder.class) {
+			EmptyBorder ourBorder = (EmptyBorder) borderValue.getValue();
 			Insets borderInsets = ourBorder.getBorderInsets();
-			m_topField.setValue(borderInsets.top);
-			m_leftField.setValue(borderInsets.left);
-			m_bottomField.setValue(borderInsets.bottom);
-			m_rightField.setValue(borderInsets.right);
 			// OK, this is our Border
-			return true;
-		} else {
-			// no, we don't know this Border
-			return false;
+			return ExecutionUtils.runLogLater(() -> {
+				m_topField.setValue(borderInsets.top);
+				m_leftField.setValue(borderInsets.left);
+				m_bottomField.setValue(borderInsets.bottom);
+				m_rightField.setValue(borderInsets.right);
+			});
 		}
+		// no, we don't know this Border
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/EtchedBorderComposite.java
@@ -15,12 +15,17 @@ package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.RadioField;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.widgets.Composite;
 
-import javax.swing.border.Border;
+import java.awt.Color;
+import java.util.concurrent.CompletableFuture;
+
+import javax.swing.SwingUtilities;
 import javax.swing.border.EtchedBorder;
 
 /**
@@ -66,17 +71,21 @@ public final class EtchedBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		if (border instanceof EtchedBorder ourBorder) {
-			m_typeField.setValue(ourBorder.getEtchType());
-			m_highlightField.setValue(ourBorder.getHighlightColor());
-			m_shadowField.setValue(ourBorder.getShadowColor());
+	public CompletableFuture<Void> setBorderValue(BorderValue borderValue) {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatcher thread");
+		if (borderValue.getValue() instanceof EtchedBorder ourBorder) {
+			int etchType = ourBorder.getEtchType();
+			Color highlightColor = ourBorder.getHighlightColor();
+			Color shadowColor = ourBorder.getShadowColor();
 			// OK, this is our Border
-			return true;
-		} else {
-			// no, we don't know this Border
-			return false;
+			return ExecutionUtils.runLogLater(() -> {
+				m_typeField.setValue(etchType);
+				m_highlightField.setValue(highlightColor);
+				m_shadowField.setValue(shadowColor);
+			});
 		}
+		// no, we don't know this Border
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/LineBorderComposite.java
@@ -12,17 +12,21 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.BooleanField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.IntegerField;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.widgets.Composite;
 
 import java.awt.Color;
+import java.util.concurrent.CompletableFuture;
 
-import javax.swing.border.Border;
+import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 
 /**
@@ -62,17 +66,21 @@ public final class LineBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		if (border instanceof LineBorder ourBorder) {
-			m_colorField.setValue(ourBorder.getLineColor());
-			m_thicknessField.setValue(ourBorder.getThickness());
-			m_typeField.setValue(ourBorder.getRoundedCorners());
+	public CompletableFuture<Void> setBorderValue(BorderValue borderValue) {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatcher thread");
+		if (borderValue.getValue() instanceof LineBorder ourBorder) {
+			Color lineColor = ourBorder.getLineColor();
+			int thickness = ourBorder.getThickness();
+			boolean roundedCorners = ourBorder.getRoundedCorners();
 			// OK, this is our Border
-			return true;
-		} else {
-			// no, we don't know this Border
-			return false;
+			return ExecutionUtils.runLogLater(() -> {
+				m_colorField.setValue(lineColor);
+				m_thicknessField.setValue(thickness);
+				m_typeField.setValue(roundedCorners);
+			});
 		}
+		// no, we don't know this Border
+		return null;
 	}
 
 	static {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/NoBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/NoBorderComposite.java
@@ -12,8 +12,14 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
+
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.widgets.Composite;
 
+import java.util.concurrent.CompletableFuture;
+
+import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 
 /**
@@ -38,8 +44,12 @@ public final class NoBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		return border == null;
+	public CompletableFuture<Void> setBorderValue(BorderValue borderValue) {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatcher thread");
+		if (borderValue.getValue() == null) {
+			return CompletableFuture.completedFuture(null);
+		}
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/pages/SoftBevelBorderComposite.java
@@ -15,13 +15,18 @@ package org.eclipse.wb.internal.swing.model.property.editor.border.pages;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
 import org.eclipse.wb.internal.swing.model.ModelMessages;
+import org.eclipse.wb.internal.swing.model.property.editor.border.BorderValue;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.ColorField;
 import org.eclipse.wb.internal.swing.model.property.editor.border.fields.RadioField;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.swt.widgets.Composite;
 
+import java.awt.Color;
+import java.util.concurrent.CompletableFuture;
+
+import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
-import javax.swing.border.Border;
 import javax.swing.border.SoftBevelBorder;
 
 /**
@@ -73,19 +78,25 @@ public final class SoftBevelBorderComposite extends AbstractBorderComposite {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public boolean setBorder(Border border) throws Exception {
-		if (border instanceof SoftBevelBorder ourBorder) {
-			m_typeField.setValue(ourBorder.getBevelType());
-			m_highlightOuterField.setValue(ourBorder.getHighlightOuterColor());
-			m_highlightInnerField.setValue(ourBorder.getHighlightInnerColor());
-			m_shadowOuterField.setValue(ourBorder.getShadowOuterColor());
-			m_shadowInnerField.setValue(ourBorder.getShadowInnerColor());
+	public CompletableFuture<Void> setBorderValue(BorderValue borderValue) {
+		Assert.isTrue(SwingUtilities.isEventDispatchThread(), "Must be called from the AWT event dispatcher thread");
+		if (borderValue.getValue() instanceof SoftBevelBorder ourBorder) {
+			int bevelType = ourBorder.getBevelType();
+			Color highlightOuterColor = ourBorder.getHighlightOuterColor();
+			Color highlightInnerColor = ourBorder.getHighlightInnerColor();
+			Color shadowOuterColor = ourBorder.getShadowOuterColor();
+			Color shadowInnerColor = ourBorder.getShadowInnerColor();
 			// OK, this is our Border
-			return true;
-		} else {
-			// no, we don't know this Border
-			return false;
+			return ExecutionUtils.runLogLater(() -> {
+				m_typeField.setValue(bevelType);
+				m_highlightOuterField.setValue(highlightOuterColor);
+				m_highlightInnerField.setValue(highlightInnerColor);
+				m_shadowOuterField.setValue(shadowOuterColor);
+				m_shadowInnerField.setValue(shadowInnerColor);
+			});
 		}
+		// no, we don't know this Border
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
This is a continuation of 979a129e5f1e21c054c013c3008be7132230580f, where the Swing border is now consumed in the AWT event dispatcher thread, rather than the SWT UI thread. Interactions between those threads are done asynchronously, to avoid accidental deadlocks.