### PR TITLE
Avoid using deprecated MigLayout methods

### DIFF
--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigColumnInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigColumnInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -115,7 +115,7 @@ public final class MigColumnInfo extends MigDimensionInfo {
 		int index = getIndex();
 		AC colSpecs = (AC) ReflectionUtils.getFieldObject(m_layout.getObject(), "colSpecs");
 		if (index < colSpecs.getCount()) {
-			return colSpecs.getConstaints()[index];
+			return colSpecs.getConstraints()[index];
 		} else {
 			return createDefaultConstraint();
 		}
@@ -123,7 +123,7 @@ public final class MigColumnInfo extends MigDimensionInfo {
 
 	@Override
 	protected DimConstraint createDefaultConstraint() {
-		return ConstraintParser.parseColumnConstraints("[]").getConstaints()[0];
+		return ConstraintParser.parseColumnConstraints("[]").getConstraints()[0];
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigDimensionInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigDimensionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -83,7 +83,7 @@ public abstract class MigDimensionInfo {
 	 */
 	public final String getString(boolean withBraces) {
 		AC ac = new AC();
-		ac.setConstaints(new DimConstraint[]{m_constraint});
+		ac.setConstraints(new DimConstraint[]{m_constraint});
 		String constraintString = IDEUtil.getConstraintString(ac, false, m_horizontal);
 		if (!withBraces) {
 			constraintString = StringUtils.strip(constraintString, "[]");
@@ -369,7 +369,7 @@ public abstract class MigDimensionInfo {
 			AC ac = new AC();
 			DimConstraint dimConstraint = new DimConstraint();
 			dimConstraint.setSize(boundSize);
-			ac.setConstaints(new DimConstraint[]{dimConstraint});
+			ac.setConstraints(new DimConstraint[]{dimConstraint});
 			String constraintString = IDEUtil.getConstraintString(ac, false, m_horizontal);
 			return StringUtils.strip(constraintString, "[]");
 		} else {
@@ -403,7 +403,7 @@ public abstract class MigDimensionInfo {
 		}
 		// extract single constraint
 		Assert.equals(1, ac.getCount(), s);
-		return ac.getConstaints()[0];
+		return ac.getConstraints()[0];
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigLayoutInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -452,7 +452,7 @@ public final class MigLayoutInfo extends LayoutInfo implements IPreferenceConsta
 		String constraintString;
 		{
 			AC ac = new AC();
-			ac.setConstaints(constraints);
+			ac.setConstraints(constraints);
 			constraintString = IDEUtil.getConstraintString(ac, false, cols);
 		}
 		// return as source

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigRowInfo.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/MigRowInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -112,7 +112,7 @@ public final class MigRowInfo extends MigDimensionInfo {
 		int index = getIndex();
 		AC colSpecs = (AC) ReflectionUtils.getFieldObject(m_layout.getObject(), "rowSpecs");
 		if (index >= 0 && index < colSpecs.getCount()) {
-			return colSpecs.getConstaints()[index];
+			return colSpecs.getConstraints()[index];
 		} else {
 			return createDefaultConstraint();
 		}
@@ -120,7 +120,7 @@ public final class MigRowInfo extends MigDimensionInfo {
 
 	@Override
 	protected DimConstraint createDefaultConstraint() {
-		return ConstraintParser.parseRowConstraints("[]").getConstaints()[0];
+		return ConstraintParser.parseRowConstraints("[]").getConstraints()[0];
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The old methods contain a typo and should be replaced with their correctly-spelled counterpart.