### PR TITLE
Don't fail tests if test files can't be deleted

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/AbstractJavaProjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -83,7 +83,7 @@ public abstract class AbstractJavaProjectTest extends DesignerTestCase {
 							resource.setResourceAttributes(attributes);
 						}
 						// do deleting
-						forceDeleteFile(resource);
+						forceDeleteResource(resource);
 						break;
 					} catch (Exception e) {
 						if (i == maxCount - 1) {
@@ -566,21 +566,21 @@ public abstract class AbstractJavaProjectTest extends DesignerTestCase {
 			if (resource instanceof IFolder) {
 				deleteFiles((IFolder) resource);
 			}
-			resource.delete(true, null);
+			forceDeleteResource(resource);
 		}
 	}
 
 	/**
-	 * Force deletes {@link IFile}.
+	 * Force deletes {@link IResource}.
 	 */
-	public static void forceDeleteFile(IFile file) {
-		while (file.exists()) {
+	public static void forceDeleteResource(IResource resource) {
+		while (resource.exists()) {
 			try {
-				file.refreshLocal(IResource.DEPTH_INFINITE, null);
+				resource.refreshLocal(IResource.DEPTH_INFINITE, null);
 			} catch (Throwable e) {
 			}
 			try {
-				file.delete(true, null);
+				resource.delete(true, null);
 			} catch (Throwable e) {
 				waitEventLoop(100);
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/IconPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/property/IconPropertyEditorTest.java
@@ -71,7 +71,7 @@ public class IconPropertyEditorTest extends SwingModelTest {
 					"  }",
 			"}"});
 		} finally {
-			forceDeleteFile(imageFile);
+			forceDeleteResource(imageFile);
 		}
 	}
 
@@ -93,7 +93,7 @@ public class IconPropertyEditorTest extends SwingModelTest {
 									"  }",
 					"}"});
 		} finally {
-			forceDeleteFile(imageFile);
+			forceDeleteResource(imageFile);
 		}
 	}
 


### PR DESCRIPTION
Some tests occasionally fail on Windows because the test files are still referenced by another process. The CoreException that should be thrown in such a case should be caught and ignored, as it is not part of the test case.