### PR TITLE
Make DesignerPackageBinding compatible with JDT 2025-12

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerPackageBinding.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/binding/DesignerPackageBinding.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IModuleBinding;
 import org.eclipse.jdt.core.dom.IPackageBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 
 /**
  * Implementation of {@link IPackageBinding}.
@@ -123,6 +124,11 @@ final class DesignerPackageBinding implements IPackageBinding {
 
 	@Override
 	public IModuleBinding getModule() {
+		throw new IllegalArgumentException();
+	}
+
+	// @Override Only added with JDT 2025-12
+	public ITypeBinding findTypeBinding(String name) {
 		throw new IllegalArgumentException();
 	}
 }


### PR DESCRIPTION
A new 'findTypeBinding(String)' method was added to IPackageBinding: https://github.com/eclipse-jdt/eclipse.jdt.core/commit/4888077d66fed785b7072431796cc79f2732538c