### PR TITLE
DesignerEditorTestCase should extend AbstractJavaInfoTest

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/editor/DesignerEditorTestCase.java
@@ -39,7 +39,7 @@ import org.eclipse.wb.internal.gef.tree.TreeViewer;
 import org.eclipse.wb.internal.rcp.databinding.DatabindingsProvider;
 import org.eclipse.wb.internal.rcp.databinding.model.widgets.WidgetsObserveTypeContainer;
 import org.eclipse.wb.tests.designer.TestUtils;
-import org.eclipse.wb.tests.designer.core.model.parser.AbstractJavaInfoRelatedTest;
+import org.eclipse.wb.tests.designer.core.model.parser.AbstractJavaInfoTest;
 import org.eclipse.wb.tests.gef.GraphicalRobot;
 import org.eclipse.wb.tests.gef.TreeRobot;
 import org.eclipse.wb.tests.gef.UiContext;
@@ -73,7 +73,7 @@ import java.util.List;
  *
  * @author scheglov_ke
  */
-public abstract class DesignerEditorTestCase extends AbstractJavaInfoRelatedTest {
+public abstract class DesignerEditorTestCase extends AbstractJavaInfoTest {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Life cycle


### PR DESCRIPTION
Some tests are occasionally failing because the EditorState is still initialized with a JavaInfo object that was created during a previous test. By extending the AbstractJavaInfoTest class, this class is now explicitly cleared after each test.

Semantically, this change also sound; The AbstractJavaInfoRelatedTest is used for test cases that don't parse JavaInfo objects. However, almost all subclasses of the DesignerEditorTestCase do so.