### PR TITLE
Restore generation of source bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-source-plugin</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-packaging-plugin</artifactId>
           <version>${tycho.version}</version>
         </plugin>
@@ -272,6 +277,19 @@
             </environment>
           </environments>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-source</id>
+            <goals>
+              <goal>plugin-source</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
This partially reverts 01d44259ea9803129574dc3ea9d6b53d6711807e, where together with the generation of source-features, the generation of source-bundles was also removed.