### PR TITLE
Always create 24-bit Swing screenshot images #1287

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingImageUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingImageUtils.java
@@ -93,8 +93,7 @@ public class SwingImageUtils {
 		final int imageWidth = Math.max(1, componentWidth);
 		final int imageHeight = Math.max(1, componentHeight);
 		// prepare empty image
-		final BufferedImage componentImage = component.getGraphicsConfiguration() //
-				.createCompatibleImage(imageWidth, imageHeight);
+		final BufferedImage componentImage = new BufferedImage(imageWidth, imageHeight, BufferedImage.TYPE_INT_RGB);
 		// If actual size on component is zero, then we are done.
 		if (componentWidth == 0 || componentHeight == 0) {
 			return componentImage;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingScreenshotMaker.java
@@ -147,8 +147,7 @@ public final class SwingScreenshotMaker {
 			double windowZoom = SwingImageUtils.getDisplayZoom(m_window);
 			int windowWidth = Math.max(1, (int) (m_window.getWidth() * windowZoom));
 			int windowHeight = Math.max(1, (int) (m_window.getHeight() * windowZoom));
-			windowImage = m_window.getGraphicsConfiguration() //
-					.createCompatibleImage(windowWidth, windowHeight);
+			windowImage = new BufferedImage(windowWidth, windowHeight, BufferedImage.TYPE_INT_RGB);
 			Graphics2D graphics = windowImage.createGraphics();
 			graphics.scale(windowZoom, windowZoom);
 			m_window.printAll(graphics);
@@ -173,8 +172,8 @@ public final class SwingScreenshotMaker {
 				componentLocation = new Point(p_component.x - p_window.x, p_component.y - p_window.y);
 			}
 			// copy part of window image
-			BufferedImage componentImage = m_component.getGraphicsConfiguration() //
-					.createCompatibleImage(componentWidth, componentHeight);
+			BufferedImage componentImage = new BufferedImage(componentWidth, componentHeight,
+					BufferedImage.TYPE_INT_RGB);
 			Graphics2D graphics = componentImage.createGraphics();
 			graphics.drawImage(
 					windowImage,


### PR DESCRIPTION
With cca651f5da13c131661d61a409900e8133001202, we always create a buffered image matching the monitor configuration. While this usually works, Swing might decide to choose an unsupported color depth when e.g. running in headless mode.

So instead, the created depth is hard-coded to one supported by our algorithm, restoring (in part) the original implementation.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1287