### PR TITLE
DesignerException should accept generic objects as parameters

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstParser.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -159,7 +159,7 @@ public final class AstParser {
 		try {
 			return (Statement) findNode(source, position, Statement.class, statementPosition);
 		} catch (DesignerException e) {
-			String problems = e.getParameters()[1];
+			Object problems = e.getParameters()[1];
 			throw new DesignerException(ICoreExceptionConstants.AST_PARSE_ERROR, e, src, problems);
 		}
 	}
@@ -179,7 +179,7 @@ public final class AstParser {
 		try {
 			return (BodyDeclaration) findNode(source, position, BodyDeclaration.class, position);
 		} catch (DesignerException e) {
-			String problems = e.getParameters()[1];
+			Object problems = e.getParameters()[1];
 			throw new DesignerException(ICoreExceptionConstants.AST_PARSE_ERROR, e, src, problems);
 		}
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/exception/DesignerException.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/exception/DesignerException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 public class DesignerException extends Error {
 	private static final long serialVersionUID = 0L;
 	private final int m_code;
-	private final String[] m_parameters;
+	private final Object[] m_parameters;
 	private final Throwable m_cause;
 	private int m_sourcePosition = -1;
 
@@ -35,11 +35,11 @@ public class DesignerException extends Error {
 	// Constructors
 	//
 	////////////////////////////////////////////////////////////////////////////
-	public DesignerException(int code, String... parameters) {
+	public DesignerException(int code, Object... parameters) {
 		this(code, null, parameters);
 	}
 
-	public DesignerException(int code, Throwable cause, String... parameters) {
+	public DesignerException(int code, Throwable cause, Object... parameters) {
 		super(cause);
 		m_code = code;
 		m_parameters = parameters;
@@ -55,7 +55,7 @@ public class DesignerException extends Error {
 		return m_code;
 	}
 
-	public String[] getParameters() {
+	public Object[] getParameters() {
 		return m_parameters;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/exception/DesignerExceptionUtils.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/exception/DesignerExceptionUtils.java
@@ -57,6 +57,7 @@ import java.net.URL;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -338,7 +339,7 @@ public final class DesignerExceptionUtils {
 		Throwable rootException = getDesignerCause(throwable);
 		if (rootException instanceof DesignerException designerException) {
 			int code = designerException.getCode();
-			String[] parameters = designerException.getParameters();
+			Object[] parameters = designerException.getParameters();
 			return getErrorEntry(code, parameters);
 		} else {
 			return getUnexpectedErrorEntryInfo(throwable);
@@ -360,7 +361,7 @@ public final class DesignerExceptionUtils {
 		return new ErrorEntryInfo(e.getCode(), e.isWarning(), e.getTitle(), desc, e.getAltDescription());
 	}
 
-	public static ErrorEntryInfo getErrorEntry(int exceptionCode, String... parameters) {
+	public static ErrorEntryInfo getErrorEntry(int exceptionCode, Object... parameters) {
 		// try to find existing entry
 		{
 			ErrorEntryInfo entry = getErrorEntry0(exceptionCode, parameters);
@@ -379,7 +380,7 @@ public final class DesignerExceptionUtils {
 		}
 	}
 
-	private static ErrorEntryInfo getErrorEntry0(int exceptionCode, String... parameters) {
+	private static ErrorEntryInfo getErrorEntry0(int exceptionCode, Object... parameters) {
 		// get error entry if any and prepare it.
 		ErrorEntryInfo errorEntryInfo = getErrorEntry0(exceptionCode);
 		if (errorEntryInfo != null) {
@@ -412,8 +413,8 @@ public final class DesignerExceptionUtils {
 		return m_codeToDescription.get(exceptionCode);
 	}
 
-	private static String includeExceptionParameter(String html, String searchString, String message) {
-		String messageEscaped = StringEscapeUtils.escapeHtml4(message);
+	private static String includeExceptionParameter(String html, String searchString, Object message) {
+		String messageEscaped = StringEscapeUtils.escapeHtml4(Objects.toString(message));
 		return html.replace(searchString, messageEscaped);
 	}
 

--- a/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.layout.group/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.layout.group;singleton:=true
-Bundle-Version: 1.9.1100.qualifier
+Bundle-Version: 1.9.1200.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/DesignerExceptionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/DesignerExceptionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -40,7 +40,7 @@ public class DesignerExceptionTest extends Assertions {
 		DesignerException designerException = new DesignerException(CODE, PARAMETER_0);
 		assertEquals(CODE, designerException.getCode());
 		{
-			String[] parameters = designerException.getParameters();
+			Object[] parameters = designerException.getParameters();
 			assertEquals(parameters.length, 1);
 			assertSame(PARAMETER_0, parameters[0]);
 		}
@@ -51,7 +51,7 @@ public class DesignerExceptionTest extends Assertions {
 		DesignerException designerException = new DesignerException(CODE, PARAMETER_0, PARAMETER_1);
 		assertEquals(CODE, designerException.getCode());
 		{
-			String[] parameters = designerException.getParameters();
+			Object[] parameters = designerException.getParameters();
 			assertEquals(parameters.length, 2);
 			assertSame(PARAMETER_0, parameters[0]);
 			assertSame(PARAMETER_1, parameters[1]);
@@ -65,7 +65,7 @@ public class DesignerExceptionTest extends Assertions {
 		assertEquals(CODE, designerException.getCode());
 		assertSame(cause, designerException.getCause());
 		{
-			String[] parameters = designerException.getParameters();
+			Object[] parameters = designerException.getParameters();
 			assertEquals(parameters.length, 1);
 			assertSame(PARAMETER_0, parameters[0]);
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/ast/AstEditorTest.java
@@ -2145,17 +2145,17 @@ public class AstEditorTest extends AbstractJavaTest {
 			DesignerException methodDE = DesignerExceptionUtils.getDesignerException(e);
 			assertEquals(ICoreExceptionConstants.AST_PARSE_ERROR, methodDE.getCode());
 			{
-				String[] parameters = methodDE.getParameters();
+				Object[] parameters = methodDE.getParameters();
 				Assertions.assertThat(parameters).hasSize(2);
 				{
-					String source = parameters[0];
+					String source = (String) parameters[0];
 					Assertions.assertThat(source).doesNotContain("class Test");
 					Assertions.assertThat(source).contains("void foo() {");
 					Assertions.assertThat(source).contains("somethingBadA();");
 					Assertions.assertThat(source).contains("somethingBadB();");
 				}
 				{
-					String problems = parameters[1];
+					String problems = (String) parameters[1];
 					Assertions.assertThat(problems).contains("The method somethingBadA() is undefined for the type Test");
 					Assertions.assertThat(problems).contains("The method somethingBadB() is undefined for the type Test");
 				}
@@ -2164,10 +2164,10 @@ public class AstEditorTest extends AbstractJavaTest {
 			DesignerException nodeDE = (DesignerException) methodDE.getCause();
 			assertEquals(ICoreExceptionConstants.AST_PARSE_ERROR, nodeDE.getCode());
 			{
-				String[] parameters = nodeDE.getParameters();
+				Object[] parameters = nodeDE.getParameters();
 				Assertions.assertThat(parameters).hasSize(2);
 				{
-					String source = parameters[0];
+					String source = (String) parameters[0];
 					Assertions.assertThat(source).contains("class Test");
 					Assertions.assertThat(source).contains("void foo() {");
 					Assertions.assertThat(source).contains("somethingBadA();");
@@ -4768,19 +4768,19 @@ public class AstEditorTest extends AbstractJavaTest {
 			DesignerException statementDE = DesignerExceptionUtils.getDesignerException(e);
 			assertEquals(ICoreExceptionConstants.AST_PARSE_ERROR, statementDE.getCode());
 			{
-				String[] parameters = statementDE.getParameters();
+				Object[] parameters = statementDE.getParameters();
 				Assertions.assertThat(parameters).hasSize(2);
-				Assertions.assertThat(parameters[0]).contains("somethingBad();");
-				Assertions.assertThat(parameters[1]).contains("The method somethingBad() is undefined");
+				Assertions.assertThat((String) parameters[0]).contains("somethingBad();");
+				Assertions.assertThat((String) parameters[1]).contains("The method somethingBad() is undefined");
 			}
 			// ASTNode "parse error" is cause
 			DesignerException nodeDE = (DesignerException) statementDE.getCause();
 			assertEquals(ICoreExceptionConstants.AST_PARSE_ERROR, nodeDE.getCode());
 			{
-				String[] parameters = nodeDE.getParameters();
+				Object[] parameters = nodeDE.getParameters();
 				Assertions.assertThat(parameters).hasSize(2);
-				Assertions.assertThat(parameters[0]).contains("somethingBad();");
-				Assertions.assertThat(parameters[1]).contains("The method somethingBad() is undefined");
+				Assertions.assertThat((String) parameters[0]).contains("somethingBad();");
+				Assertions.assertThat((String) parameters[1]).contains("The method somethingBad() is undefined");
 			}
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/check/AssertTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/util/check/AssertTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -328,7 +328,7 @@ public class AssertTest extends Assertions {
 			fail();
 		} catch (DesignerException e) {
 			assertEquals(exceptionCode, e.getCode());
-			String[] parameters = e.getParameters();
+			Object[] parameters = e.getParameters();
 			assertEquals(1, parameters.length);
 			assertSame(message, parameters[0]);
 		}
@@ -344,7 +344,7 @@ public class AssertTest extends Assertions {
 			fail();
 		} catch (DesignerException e) {
 			assertEquals(exceptionCode, e.getCode());
-			String[] parameters = e.getParameters();
+			Object[] parameters = e.getParameters();
 			assertEquals(1, parameters.length);
 			assertEquals("10", parameters[0]);
 		}
@@ -360,7 +360,7 @@ public class AssertTest extends Assertions {
 			fail();
 		} catch (DesignerException e) {
 			assertEquals(exceptionCode, e.getCode());
-			String[] parameters = e.getParameters();
+			Object[] parameters = e.getParameters();
 			assertEquals(1, parameters.length);
 			assertEquals("null", parameters[0]);
 		}


### PR DESCRIPTION
This avoids having to manually call toString() on non-String parameters (such as ints or other objects with a human-readable toString() method).