### PR TITLE
Make dependency from test plugin to OS support implementation explicit

### DIFF
--- a/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package: org.apache.commons.io;version="[2.16.1,3.0.0)",
  org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.wb.os
 Automatic-Module-Name: org.eclipse.wb.os.linux
+Provide-Capability: wbp;type=os

--- a/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.macosx;singleton:=true
-Bundle-Version: 1.9.800.qualifier
+Bundle-Version: 1.9.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-PlatformFilter: (osgi.os=macosx)
@@ -18,4 +18,5 @@ Bundle-Localization: plugin
 Import-Package: org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.wb.os
 Automatic-Module-Name: org.eclipse.wb.os.macosx
+Provide-Capability: wbp;type=os
 

--- a/org.eclipse.wb.os.macosx/pom.xml
+++ b/org.eclipse.wb.os.macosx/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.macosx</artifactId>
-    <version>1.9.800-SNAPSHOT</version>
+    <version>1.9.900-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.win32/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.win32;singleton:=true
-Bundle-Version: 1.10.200.qualifier
+Bundle-Version: 1.10.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
@@ -14,3 +14,4 @@ Bundle-Localization: plugin
 Import-Package: org.apache.commons.lang3;version="[3.14.0,4.0.0)",
  org.eclipse.wb.os
 Automatic-Module-Name: org.eclipse.wb.os.win32
+Provide-Capability: wbp;type=os

--- a/org.eclipse.wb.os.win32/pom.xml
+++ b/org.eclipse.wb.os.win32/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.win32</artifactId>
-    <version>1.10.200-SNAPSHOT</version>
+    <version>1.10.300-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -164,4 +164,4 @@ Import-Package: com.jgoodies.forms.factories;version="[1.9.0,2.0.0]",
  org.assertj.core.util;version="[3.26.0,4.0.0)",
  org.slf4j;version="[1.7.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.wb.tests
-
+Require-Capability: wbp;filter:="(type=os)"


### PR DESCRIPTION
The latest version of PDE calculates the minimal set of required plugins when executing a test case. Because there is no clear dependency from "org.eclipse.wb.so" to its platform-specific implementations, only an incomplete set of plugins is selected, which leads to an OSSupportError during execution.

We can add them directly due to their platform filter. So instead the dependency is described via the "Provide-Capability" and "Require-Capability" OSGi headers.