### PR TITLE
Only run license check on changes to the .target file

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,12 @@
+name: License Check
+
+on:
+  pull_request:
+    paths:
+      - '**.target'
+
+jobs:
+  check-dash-licenses:
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@fce3439d169005fa3a33df074fec5690887ecab3 # 1.1.0
+    with:
+      projectId: tools.windowbuilder

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -18,11 +18,6 @@ on:
       - labeled
 
 jobs:
-  check-dash-licenses:
-    if: contains(github.event.pull_request.labels.*.name, 'dash-license')
-    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@fce3439d169005fa3a33df074fec5690887ecab3 # 1.1.0
-    with:
-      projectId: tools.windowbuilder
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
This avoids the hassle of en-/disabling the GitHub tag.