### PR TITLE
Typify methods in OSSupport

### DIFF
--- a/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 
@@ -140,8 +141,8 @@ public abstract class OSSupportLinux extends OSSupport {
 	}
 
 	@Override
-	public void beginShot(Object controlObject) {
-		Shell shell = layoutShell(controlObject);
+	public void beginShot(Control control) {
+		Shell shell = layoutShell(control);
 		// setup key title to be used by compiz WM (if enabled)
 		if (!isWorkaroundsDisabled()) {
 			// prepare
@@ -171,10 +172,10 @@ public abstract class OSSupportLinux extends OSSupport {
 	}
 
 	@Override
-	public void endShot(Object controlObject) {
+	public void endShot(Control control) {
 		// hide shell. The shell should be visible during all the period of fetching visual data.
-		super.endShot(controlObject);
-		Shell shell = getShell(controlObject);
+		super.endShot(control);
+		Shell shell = getShell(control);
 		if (!isWorkaroundsDisabled()) {
 			_gtk_widget_hide(getShellHandle(shell));
 			if (m_eclipseShell != null) {
@@ -184,8 +185,8 @@ public abstract class OSSupportLinux extends OSSupport {
 	}
 
 	@Override
-	public void makeShots(Object controlObject) throws Exception {
-		Shell shell = getShell(controlObject);
+	public void makeShots(Control control) throws Exception {
+		Shell shell = getShell(control);
 		makeShots0(shell);
 		// check for decorations and draw if needed
 		drawDecorations(shell, shell.getDisplay());
@@ -518,7 +519,7 @@ public abstract class OSSupportLinux extends OSSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public final Rectangle getTabItemBounds(Object tabItem) {
+	public final Rectangle getTabItemBounds(TabItem tabItem) {
 		return getWidgetBounds(tabItem);
 	}
 

--- a/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSX.java
+++ b/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSX.java
@@ -67,26 +67,25 @@ public abstract class OSSupportMacOSX extends OSSupport {
 	}
 
 	@Override
-	public void beginShot(Object controlObject) {
+	public void beginShot(Control control) {
 		// disabling shell redraw prevents painting events
 		// to be dispatched to design canvas. These events can
 		// cause painting already disposed images, ex., for action instances,
 		// which are already disposed but image references are still alive
 		// in it's presentation in widgets tree (see Case 40141).
 		DesignerPlugin.getShell().setRedraw(false);
-		super.beginShot(controlObject);
+		super.beginShot(control);
 	}
 
 	@Override
-	public void endShot(Object controlObject) {
-		super.endShot(controlObject);
+	public void endShot(Control control) {
+		super.endShot(control);
 		DesignerPlugin.getShell().setRedraw(true);
 	}
 
 	@Override
-	public void makeShots(Object controlObject) throws Exception {
+	public void makeShots(Control control) throws Exception {
 		// do create shots
-		Control control = (Control) controlObject;
 		try {
 			//			reverseDrawingOrder(control);
 			Image sourceShot = makeShot(control);
@@ -278,8 +277,7 @@ public abstract class OSSupportMacOSX extends OSSupport {
 	}
 
 	@Override
-	public Rectangle getTabItemBounds(Object item) {
-		TabItem tabItem = (TabItem) item;
+	public Rectangle getTabItemBounds(TabItem tabItem) {
 		TabFolder folder = tabItem.getParent();
 		GC gc = new GC(folder);
 		Point folderSize = folder.getSize();

--- a/org.eclipse.wb.os.win32/src/org/eclipse/wb/internal/os/win32/OSSupportWin32.java
+++ b/org.eclipse.wb.os.win32/src/org/eclipse/wb/internal/os/win32/OSSupportWin32.java
@@ -63,8 +63,7 @@ public abstract class OSSupportWin32<H extends Number> extends OSSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public final void makeShots(Object controlObject) throws Exception {
-		Control control = (Control) controlObject;
+	public final void makeShots(Control control) throws Exception {
 		try {
 			reverseDrawingOrder(control);
 			makeShotsHierarchy(control);
@@ -139,9 +138,9 @@ public abstract class OSSupportWin32<H extends Number> extends OSSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public final Rectangle getTabItemBounds(Object tabItemObject) {
-		TabFolder tabFolder = ((TabItem) tabItemObject).getParent();
-		int index = ArrayUtils.indexOf(tabFolder.getItems(), tabItemObject);
+	public final Rectangle getTabItemBounds(TabItem tabItem) {
+		TabFolder tabFolder = tabItem.getParent();
+		int index = ArrayUtils.indexOf(tabFolder.getItems(), tabItem);
 		int[] bounds = new int[4];
 		getTabItemBounds(tabFolder, index, bounds);
 		// convert into Rectangle

--- a/org.eclipse.wb.os/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os;singleton:=true
-Bundle-Version: 1.9.300.qualifier
+Bundle-Version: 1.10.0.qualifier
 Bundle-Activator: org.eclipse.wb.os.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
+++ b/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -86,17 +86,45 @@ public abstract class OSSupport {
 	 * Created image can be requested using {@link ToolkitSupport#getShotImage(Object)}.
 	 *
 	 * Note: the control may have <code>null</code> as image, ex. if the control has the invalid size.
+	 *
+	 * @deprecated Use {@link #makeShots(Control)} instead. This method will be
+	 *             removed after the 2027-12 release.
 	 */
-	public abstract void makeShots(Object control) throws Exception;
+	@Deprecated(forRemoval = true, since = "2025-12")
+	public final void makeShots(Object control) throws Exception {
+		makeShots((Control) control);
+	}
+
+	/**
+	 * Prepares shots for all {@link Control}'s in hierarchy that have flag
+	 * {@link #WBP_NEED_IMAGE}. Created image can be requested using
+	 * {@link ToolkitSupport#getShotImage(Object)}.
+	 *
+	 * Note: the control may have <code>null</code> as image, ex. if the control has
+	 * the invalid size.
+	 */
+	public abstract void makeShots(Control control) throws Exception;
 
 	/**
 	 * Prepares the process of taking screen shot. Overridden in Linux.
 	 *
 	 * @param control
 	 *          the {@link Control}.
+	 * @deprecated Use {@link #beginShot(Control)} instead. This method will be
+	 *             removed after the 2027-12 release.
 	 */
-	public void beginShot(Object controlObject) {
-		Shell shell = layoutShell(controlObject);
+	@Deprecated(forRemoval = true, since = "2025-12")
+	public final void beginShot(Object controlObject) {
+		beginShot((Control) controlObject);
+	}
+
+	/**
+	 * Prepares the process of taking screen shot. Overridden in Linux.
+	 *
+	 * @param control the {@link Control}.
+	 */
+	public void beginShot(Control control) {
+		Shell shell = layoutShell(control);
 		// make visible
 		makeShellVisible(shell);
 	}
@@ -109,8 +137,20 @@ public abstract class OSSupport {
 		shell.setVisible(true);
 	}
 
+	/**
+	 * @deprecated Use {@link #layoutShell(Control)} instead. This method will be
+	 *             removed after the 2027-12 release.
+	 */
+	@Deprecated(forRemoval = true, since = "2025-12")
 	protected final Shell layoutShell(Object controlObject) {
 		Control control = (Control) controlObject;
+		Shell shell = control.getShell();
+		doLayout(shell);
+		fixZeroSizes_begin(shell);
+		return shell;
+	}
+
+	protected final Shell layoutShell(Control control) {
 		Shell shell = control.getShell();
 		doLayout(shell);
 		fixZeroSizes_begin(shell);
@@ -140,9 +180,20 @@ public abstract class OSSupport {
 	 *
 	 * @param control
 	 *          the {@link Control}.
+	 * @deprecated Use {@link #endShot(Control)} instead. This method will
+	 *             be removed after the 2027-12 release.
 	 */
-	public void endShot(Object controlObject) {
-		Control control = (Control) controlObject;
+	@Deprecated(forRemoval = true, since = "2025-12")
+	public final void endShot(Object controlObject) {
+		endShot((Control) controlObject);
+	}
+
+	/**
+	 * Finalizes the process of taking screen shot. Overridden in Linux.
+	 *
+	 * @param control the {@link Control}.
+	 */
+	public void endShot(Control control) {
 		fixZeroSizes_end(control);
 		Shell shell = control.getShell();
 		shell.setVisible(false);
@@ -152,7 +203,7 @@ public abstract class OSSupport {
 	 * Return the {@link Image} of given {@link Control}.
 	 *
 	 * Note: may return <code>null</code> as image, ex. if the control has the invalid size. See also
-	 * {@link OSSupport#makeShots(Object)}.
+	 * {@link OSSupport#makeShots(Control)}.
 	 *
 	 * @return the {@link Image} of given {@link Control}.
 	 */
@@ -211,8 +262,18 @@ public abstract class OSSupport {
 	////////////////////////////////////////////////////////////////////////////
 	/**
 	 * @return the bounds of {@link TabItem}.
+	 * @deprecated Use {@link #getTabItemBounds(TabItem)} instead. This method will
+	 *             be removed after the 2027-12 release.
 	 */
-	public abstract Rectangle getTabItemBounds(Object item);
+	@Deprecated(forRemoval = true, since = "2025-12")
+	public final Rectangle getTabItemBounds(Object item) {
+		return getTabItemBounds((TabItem) item);
+	}
+
+	/**
+	 * @return the bounds of {@link TabItem}.
+	 */
+	public abstract Rectangle getTabItemBounds(TabItem item);
 
 	////////////////////////////////////////////////////////////////////////////
 	//

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/TabItemInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/TabItemInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -54,7 +54,7 @@ public final class TabItemInfo extends AbstractTabItemInfo {
 		super.refresh_fetch();
 		// set bounds
 		{
-			Rectangle bounds = new Rectangle(OSSupport.get().getTabItemBounds(getObject()));
+			Rectangle bounds = new Rectangle(OSSupport.get().getTabItemBounds(getWidget()));
 			setModelBounds(bounds);
 		}
 	}


### PR DESCRIPTION
These methods accept a plain Object, rather than an SWT widget. This was originally done to avoid a ClassCastException when the widgets were loaded by a different classloader.
However, this type-cast is done regardless.