### PR TITLE
Mark OSSupport.setAlpha() and OSSupport.getAlpha() for removal

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/GhostWindow.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/GhostWindow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,7 +13,6 @@
 package org.eclipse.wb.core.controls;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
-import org.eclipse.wb.os.OSSupport;
 
 import org.eclipse.draw2d.geometry.Interval;
 import org.eclipse.jface.window.Window;
@@ -90,7 +89,7 @@ public abstract class GhostWindow extends Window {
 	private final void setup() {
 		Point mouseLocation = DesignerPlugin.getStandardDisplay().getCursorLocation();
 		getShell().setLocation(mouseLocation.x + INITIAL_DISTANCE, mouseLocation.y + INITIAL_DISTANCE);
-		setAlpha(getShell(), (int) (255 - INITIAL_DISTANCE * ALPHA_MULTIPLIER * SQRT_OF_TWO));
+		getShell().setAlpha((int) (255 - INITIAL_DISTANCE * ALPHA_MULTIPLIER * SQRT_OF_TWO));
 		m_listener.setEnabled(true);
 	}
 
@@ -137,22 +136,22 @@ public abstract class GhostWindow extends Window {
 			// if the mouse moved too far then the user don't need this window
 			if (distance > MAX_DISTANCE) {
 				m_enabled = false;
-				setAlpha(m_shell, 0);
+				m_shell.setAlpha(0);
 				// for platforms which doesn't support alpha
-				if (getAlpha(m_shell) == 255) {
+				if (m_shell.getAlpha() == 255) {
 					m_shell.setVisible(false);
 				}
 				return;
 			}
 			// if inside, don't set alpha again and again, this flickering for me
 			if (inside) {
-				if (getAlpha(m_shell) < 255) {
-					setAlpha(m_shell, 255);
+				if (m_shell.getAlpha() < 255) {
+					m_shell.setAlpha(255);
 				}
 			} else {
 				// proportionally set alpha
 				int alpha = 255 - distance * ALPHA_MULTIPLIER;
-				setAlpha(m_shell, alpha > 0 ? alpha : 0);
+				m_shell.setAlpha(alpha > 0 ? alpha : 0);
 			}
 		}
 
@@ -162,18 +161,5 @@ public abstract class GhostWindow extends Window {
 		public final void setEnabled(boolean enabled) {
 			m_enabled = enabled;
 		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Alpha helpers
-	//
-	////////////////////////////////////////////////////////////////////////////
-	private static void setAlpha(Shell shell, int alpha) {
-		OSSupport.get().setAlpha(shell, alpha);
-	}
-
-	private static int getAlpha(Shell shell) {
-		return OSSupport.get().getAlpha(shell);
 	}
 }

--- a/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.linux;singleton:=true
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux))

--- a/org.eclipse.wb.os.linux/pom.xml
+++ b/org.eclipse.wb.os.linux/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.linux</artifactId>
-    <version>1.10.300-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -534,26 +534,6 @@ public abstract class OSSupportLinux extends OSSupport {
 
 	////////////////////////////////////////////////////////////////////////////
 	//
-	// Alpha
-	//
-	////////////////////////////////////////////////////////////////////////////
-	@Override
-	public void setAlpha(Shell shell, int alpha) {
-		if (_gtk_widget_is_composited(getShellHandle(shell))) {
-			_gtk_widget_set_opacity(getShellHandle(shell), alpha / 255.0);
-		}
-	}
-
-	@Override
-	public int getAlpha(Shell shell) {
-		if (_gtk_widget_is_composited(getShellHandle(shell))) {
-			return (int) (_gtk_widget_get_opacity(getShellHandle(shell)) * 255);
-		}
-		return 255;
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
 	// Tree
 	//
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.macosx;singleton:=true
-Bundle-Version: 1.9.900.qualifier
+Bundle-Version: 1.10.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-PlatformFilter: (osgi.os=macosx)

--- a/org.eclipse.wb.os.macosx/pom.xml
+++ b/org.eclipse.wb.os.macosx/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.macosx</artifactId>
-    <version>1.9.900-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSXCocoa.java
+++ b/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSXCocoa.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -125,21 +125,6 @@ public abstract class OSSupportMacOSXCocoa<H extends Number> extends OSSupportMa
 		fixupSeparatorItems(menu, bounds, menuSize, itemsBounds);
 		gc.dispose();
 		return image;
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Misc
-	//
-	////////////////////////////////////////////////////////////////////////////
-	@Override
-	public int getAlpha(Shell shell) {
-		return _getAlpha(getID(shell, "window"));
-	}
-
-	@Override
-	public void setAlpha(Shell shell, int alpha) {
-		_setAlpha(getID(shell, "window"), alpha);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.os.win32/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.win32;singleton:=true
-Bundle-Version: 1.10.300.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",

--- a/org.eclipse.wb.os.win32/pom.xml
+++ b/org.eclipse.wb.os.win32/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.win32</artifactId>
-    <version>1.10.300-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.win32/src/org/eclipse/wb/internal/os/win32/OSSupportWin32.java
+++ b/org.eclipse.wb.os.win32/src/org/eclipse/wb/internal/os/win32/OSSupportWin32.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -231,21 +231,6 @@ public abstract class OSSupportWin32<H extends Number> extends OSSupport {
 	@Override
 	public int getDefaultMenuBarHeight() {
 		return _getDefaultMenuBarHeight();
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Alpha
-	//
-	////////////////////////////////////////////////////////////////////////////
-	@Override
-	public void setAlpha(Shell shell, int alpha) {
-		_setAlpha(getHandleField(shell), alpha);
-	}
-
-	@Override
-	public int getAlpha(Shell shell) {
-		return _getAlpha(getHandleField(shell));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.os/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os;singleton:=true
-Bundle-Version: 1.10.0.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Activator: org.eclipse.wb.os.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
+++ b/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
@@ -287,8 +287,12 @@ public abstract class OSSupport {
 	 *          the instance of {@link Shell} to set the alpha.
 	 * @param alpha
 	 *          the value of alpha, 0-255, not validated.
+	 * @deprecated Use {@link Shell#setAlpha(int)} directly.
 	 */
-	public abstract void setAlpha(Shell shell, int alpha);
+	@Deprecated(forRemoval = true, since = "1.23.0")
+	public void setAlpha(Shell shell, int alpha) {
+		shell.setAlpha(alpha);
+	}
 
 	/**
 	 * Returns the current alpha value for given <code>shell</code>.
@@ -296,8 +300,12 @@ public abstract class OSSupport {
 	 * @param shell
 	 *          the instance of {@link Shell} to get the alpha.
 	 * @return the alpha value.
+	 * @deprecated Use {@link Shell#getAlpha()} directly.
 	 */
-	public abstract int getAlpha(Shell shell);
+	@Deprecated(forRemoval = true, since = "1.23.0")
+	public int getAlpha(Shell shell) {
+		return shell.getAlpha();
+	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//


### PR DESCRIPTION
The implementation for each platform is identical to the one in SWT. So we can simply call `shell.getAlpha()` and `shell.setAlpha()` directly.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1301