### PR TITLE
Remove unused Point parameter from PropertyEditor.doubleClick()

### DIFF
--- a/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core.java/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core.java;singleton:=true
-Bundle-Version: 1.13.300.qualifier
+Bundle-Version: 1.13.400.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/InnerClassPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/InnerClassPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -163,7 +163,7 @@ IConfigurablePropertyObject {
 	}
 
 	@Override
-	public void doubleClick(Property property, Point location) throws Exception {
+	public void doubleClick(Property property) throws Exception {
 		openClass(property);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/complex/InstanceObjectPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/editor/complex/InstanceObjectPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -127,7 +127,7 @@ IConfigurablePropertyObject {
 	}
 
 	@Override
-	public void doubleClick(Property property, Point location) throws Exception {
+	public void doubleClick(Property property) throws Exception {
 		if (!StringUtils.isEmpty(m_sourceNewClass)) {
 			openClass(property);
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerMethodPropertyEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerMethodPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,7 +60,7 @@ final class ListenerMethodPropertyEditor extends TextDisplayPropertyEditor {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void doubleClick(Property property, Point location) throws Exception {
+	public void doubleClick(Property property) throws Exception {
 		openStubMethod(property);
 	}
 

--- a/org.eclipse.wb.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.core;singleton:=true
-Bundle-Version: 1.22.0.qualifier
+Bundle-Version: 1.23.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.core.DesignerPlugin

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanObjectPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanObjectPropertyEditor.java
@@ -94,7 +94,7 @@ public final class BooleanObjectPropertyEditor extends PropertyEditor {
 	}
 
 	@Override
-	public void doubleClick(Property property, Point location) throws Exception {
+	public void doubleClick(Property property) throws Exception {
 		invertValue(property);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanPropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/BooleanPropertyEditor.java
@@ -92,7 +92,7 @@ public final class BooleanPropertyEditor extends PropertyEditor {
 	}
 
 	@Override
-	public void doubleClick(Property property, Point location) throws Exception {
+	public void doubleClick(Property property) throws Exception {
 		invertValue(property);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/PropertyEditor.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/PropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -97,11 +97,8 @@ public abstract class PropertyEditor implements IAdaptable {
 
 	/**
 	 * Handles double click on {@link Property} value in {@link PropertyTable}.
-	 *
-	 * @param location
-	 *          the mouse location, relative to editor
 	 */
-	public void doubleClick(Property property, Point location) throws Exception {
+	public void doubleClick(Property property) throws Exception {
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -658,7 +658,7 @@ public class PropertyTable extends ScrollingGraphicalViewer {
 							m_activePropertyInfo.flip();
 						} else {
 							Property property = m_activePropertyInfo.getProperty();
-							property.getEditor().doubleClick(property, getValueRelativeLocation(event.x, event.y));
+							property.getEditor().doubleClick(property);
 						}
 					}
 				} catch (Throwable e) {

--- a/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp;singleton:=true
-Bundle-Version: 1.9.1300.qualifier
+Bundle-Version: 1.9.1400.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.rcp.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/viewers/TableViewerColumnSorterPropertyEditor.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/jface/viewers/TableViewerColumnSorterPropertyEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -26,7 +26,6 @@ import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.core.utils.jdt.core.ProjectUtils;
 import org.eclipse.wb.internal.rcp.Activator;
 
-import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jface.viewers.TableViewer;
 
@@ -66,7 +65,7 @@ public final class TableViewerColumnSorterPropertyEditor extends TextDisplayProp
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	public void doubleClick(Property _property, Point location) throws Exception {
+	public void doubleClick(Property _property) throws Exception {
 		JavaProperty property = (JavaProperty) _property;
 		final JavaInfo javaInfo = property.getJavaInfo();
 		ASTNode node = (ASTNode) property.getValue();
@@ -108,6 +107,6 @@ public final class TableViewerColumnSorterPropertyEditor extends TextDisplayProp
 			}
 		});
 		// open in source
-		doubleClick(_property, location);
+		doubleClick(_property);
 	}
 }

--- a/org.eclipse.wb.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: WindowBuilder Tests
 Bundle-SymbolicName: org.eclipse.wb.tests;singleton:=true
-Bundle-Version: 1.7.200.qualifier
+Bundle-Version: 1.7.300.qualifier
 Bundle-Activator: org.eclipse.wb.tests.designer.tests.Activator
 Bundle-Vendor: Google
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.wb.tests/pom.xml
+++ b/org.eclipse.wb.tests/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.wb</groupId>
   <artifactId>org.eclipse.wb.tests</artifactId>
-  <version>1.7.200-SNAPSHOT</version>
+  <version>1.7.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 	<properties>

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/EventsPropertyTest.java
@@ -2250,7 +2250,7 @@ public class EventsPropertyTest extends SwingModelTest implements IPreferenceCon
 		// open "keyPressed" method
 		{
 			PropertyEditor keyPressedEditor = keyPressedProperty.getEditor();
-			keyPressedEditor.doubleClick(keyPressedProperty, null);
+			keyPressedEditor.doubleClick(keyPressedProperty);
 			assertEditor(
 					"class Test extends JPanel {",
 					"  Test() {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanObjectPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanObjectPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,7 +60,7 @@ public class BooleanObjectPropertyEditorTest extends AbstractTextPropertyEditorT
 		Property property = panel.getPropertyByTitle("foo");
 		BooleanObjectPropertyEditor editor = (BooleanObjectPropertyEditor) property.getEditor();
 		// unknown -> true
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends MyPanel {",
@@ -69,7 +69,7 @@ public class BooleanObjectPropertyEditorTest extends AbstractTextPropertyEditorT
 				"  }",
 				"}");
 		// true -> false
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends MyPanel {",
@@ -78,7 +78,7 @@ public class BooleanObjectPropertyEditorTest extends AbstractTextPropertyEditorT
 				"  }",
 				"}");
 		// false -> true
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends MyPanel {",
@@ -107,7 +107,7 @@ public class BooleanObjectPropertyEditorTest extends AbstractTextPropertyEditorT
 		Property property = panel.getPropertyByTitle("foo");
 		BooleanObjectPropertyEditor editor = (BooleanObjectPropertyEditor) property.getEditor();
 		// null -> true
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends MyPanel {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/BooleanPropertyEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -59,7 +59,7 @@ public class BooleanPropertyEditorTest extends AbstractTextPropertyEditorTest {
 		Property property = panel.getPropertyByTitle("foo");
 		BooleanPropertyEditor editor = (BooleanPropertyEditor) property.getEditor();
 		// unknown -> true
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends MyPanel {",
@@ -68,7 +68,7 @@ public class BooleanPropertyEditorTest extends AbstractTextPropertyEditorTest {
 				"  }",
 				"}");
 		// true -> false
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends MyPanel {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/InnerClassPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/InnerClassPropertyEditorTest.java
@@ -100,7 +100,7 @@ public class InnerClassPropertyEditorTest extends SwingModelTest {
 			IDesignPageSite designerPageSite = mock(IDesignPageSite.class);
 			// use DesignPageSite, open position
 			DesignPageSite.Helper.setSite(button, designerPageSite);
-			propertyEditor.doubleClick(property, null);
+			propertyEditor.doubleClick(property);
 			//
 			verify(designerPageSite).openSourcePosition(expectedPosition);
 			verifyNoMoreInteractions(designerPageSite);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/InstanceObjectPropertyEditorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/property/editor/InstanceObjectPropertyEditorTest.java
@@ -210,7 +210,7 @@ public class InstanceObjectPropertyEditorTest extends SwingModelTest {
 		//editor
 		InstanceObjectPropertyEditor editor = (InstanceObjectPropertyEditor) property.getEditor();
 		// kick "doubleClick"
-		editor.doubleClick(property, null);
+		editor.doubleClick(property);
 		assertEditor(
 				"// filler filler filler",
 				"public class Test extends TestPanel {",

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/TableViewerColumnTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/TableViewerColumnTest.java
@@ -600,7 +600,7 @@ public class TableViewerColumnTest extends RcpModelTest {
 			IDesignPageSite designerPageSite = mock(IDesignPageSite.class);
 			// use DesignPageSite, open position
 			DesignPageSite.Helper.setSite(shell, designerPageSite);
-			sorterEditor.doubleClick(sorterProperty, null);
+			sorterEditor.doubleClick(sorterProperty);
 			//
 			verify(designerPageSite).openSourcePosition(positionCapture.capture());
 			// source

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/jface/ViewerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/jface/ViewerTest.java
@@ -687,7 +687,7 @@ public class ViewerTest extends RcpModelTest {
 			assertEquals("test.Test.ContentProvider", getPropertyText(property));
 		}
 		// just kick "doubleClick", no result tested
-		propertyEditor.doubleClick(property, null);
+		propertyEditor.doubleClick(property);
 		// use GUI to set "ArrayContentProvider"
 		{
 			String expectedSource = m_lastEditor.getSource().replace("new ContentProvider", "new ArrayContentProvider");


### PR DESCRIPTION
This parameter is never used and sometimes even set to null.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1303