### PR TITLE
Make our TreeViewer more like a GEF TreeViewer

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -13,7 +13,6 @@
 package org.eclipse.wb.internal.gef.tree;
 
 import org.eclipse.wb.gef.tree.TreeEditPart;
-import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
@@ -23,6 +22,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Cursor;
@@ -41,21 +41,13 @@ import java.util.List;
  * @coverage gef.tree
  */
 public class TreeViewer extends AbstractEditPartViewer {
-	private final Tree m_tree;
-	private final RootEditPart m_rootEditPart;
-	private final TreeEventManager m_eventManager;
+	private Tree m_tree;
+	private RootEditPart m_rootEditPart;
+	private TreeEventManager m_eventManager;
 
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Constructors
-	//
-	////////////////////////////////////////////////////////////////////////////
-	public TreeViewer(Composite parent, int style) {
-		this(new Tree(parent, style));
-	}
-
-	public TreeViewer(Tree tree) {
-		m_tree = tree;
+	@Override
+	public Control createControl(Composite parent) {
+		m_tree = new Tree(parent, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
 		// handle SWT events
 		m_eventManager = new TreeEventManager(m_tree, this);
 		// create root EditPart
@@ -65,6 +57,7 @@ public class TreeViewer extends AbstractEditPartViewer {
 		setRootEditPart(m_rootEditPart);
 		// handle selection events
 		synchronizeSelection();
+		return m_tree;
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -72,18 +65,12 @@ public class TreeViewer extends AbstractEditPartViewer {
 	// Access
 	//
 	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * @return the {@link Tree} control for this viewer.
-	 */
-	public Tree getTree() {
-		return m_tree;
-	}
 
 	/**
 	 * Returns the SWT <code>Control</code> for this viewer.
 	 */
 	@Override
-	public Control getControl() {
+	public Tree getControl() {
 		return m_tree;
 	}
 
@@ -127,25 +114,6 @@ public class TreeViewer extends AbstractEditPartViewer {
 	@Override
 	public void setCursor(Cursor cursor) {
 		m_tree.setCursor(cursor);
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Expansion
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Collapses all items in underlying {@link Tree}.
-	 */
-	public void collapseAll() {
-		UiUtils.collapseAll(m_tree);
-	}
-
-	/**
-	 * Expands all items in underlying {@link Tree}.
-	 */
-	public void expandAll() {
-		UiUtils.expandAll(m_tree);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gefTree/part/ObjectEditPart.java
@@ -68,7 +68,7 @@ public class ObjectEditPart extends TreeEditPart {
 		super.activate();
 		if (m_object.isRoot()) {
 			final TreeViewer viewer = (TreeViewer) getViewer();
-			final Tree tree = viewer.getTree();
+			final Tree tree = viewer.getControl();
 			// update presentation only when EditPart become visible
 			{
 				m_updatePresentationListener = new Listener() {
@@ -146,7 +146,7 @@ public class ObjectEditPart extends TreeEditPart {
 	public void deactivate() {
 		if (m_updatePresentationListener != null) {
 			TreeViewer viewer = (TreeViewer) getViewer();
-			Tree tree = viewer.getTree();
+			Tree tree = viewer.getControl();
 			tree.removeListener(SWT.PaintItem, m_updatePresentationListener);
 		}
 		super.deactivate();

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/components/ComponentsTreePage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/components/ComponentsTreePage.java
@@ -37,7 +37,6 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
@@ -70,7 +69,8 @@ public final class ComponentsTreePage implements IPage {
 
 	@Override
 	public void createControl(Composite parent) {
-		m_viewer = new TreeViewer(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI);
+		m_viewer = new TreeViewer();
+		m_viewer.createControl(parent);
 		m_viewer.addSelectionChangedListener(m_selectionListener_Tree);
 	}
 
@@ -90,7 +90,7 @@ public final class ComponentsTreePage implements IPage {
 			IAction action = new Action() {
 				@Override
 				public void run() {
-					UiUtils.expandAll(m_viewer.getTree());
+					UiUtils.expandAll(m_viewer.getControl());
 				}
 			};
 			toolBarManager.add(action);
@@ -101,7 +101,7 @@ public final class ComponentsTreePage implements IPage {
 			Action action = new Action() {
 				@Override
 				public void run() {
-					UiUtils.collapseAll(m_viewer.getTree());
+					UiUtils.collapseAll(m_viewer.getControl());
 				}
 			};
 			toolBarManager.add(action);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/components/ComponentsTreeWrapper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/structure/components/ComponentsTreeWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -44,7 +44,7 @@ final class ComponentsTreeWrapper implements IComponentsTree {
 		m_viewer = viewer;
 		m_contentProvider = new EditPartsContentProvider(m_viewer);
 		m_selectionProvider = new EditPartsSelectionProvider(m_viewer);
-		m_viewer.getTree().addTreeListener(new TreeListener() {
+		m_viewer.getControl().addTreeListener(new TreeListener() {
 			@Override
 			public void treeCollapsed(TreeEvent e) {
 				if (m_expandListener != null) {
@@ -85,7 +85,7 @@ final class ComponentsTreeWrapper implements IComponentsTree {
 
 	@Override
 	public Object[] getExpandedElements() {
-		TreeItem[] expandedItems = UiUtils.getExpanded(m_viewer.getTree());
+		TreeItem[] expandedItems = UiUtils.getExpanded(m_viewer.getControl());
 		// prepare models
 		Object[] models = new Object[expandedItems.length];
 		for (int i = 0; i < expandedItems.length; i++) {
@@ -106,7 +106,7 @@ final class ComponentsTreeWrapper implements IComponentsTree {
 			editParts[i] = (EditPart) m_viewer.getEditPartRegistry().get(element);
 		}
 		// expand using EditPart's
-		UiUtils.setExpandedByData(m_viewer.getTree(), editParts);
+		UiUtils.setExpandedByData(m_viewer.getControl(), editParts);
 	}
 
 	@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ApplicationWindowGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/ApplicationWindowGefTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -268,7 +268,7 @@ public class ApplicationWindowGefTest extends RcpGefTest {
 				"}");
 		ActionInfo action2 = getJavaInfoByName("m_action2");
 		// we need this, because only in this case under Win32 we will able to reproduce problem
-		m_viewerTree.getTree().setFocus();
+		m_viewerTree.getControl().setFocus();
 		// delete
 		tree.expandAll();
 		tree.select(action2);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeCreateToolTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeCreateToolTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,6 @@ package org.eclipse.wb.tests.gef;
 import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.tools.CreationTool;
 import org.eclipse.wb.gef.tree.TreeEditPart;
-import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 
 import org.eclipse.draw2d.geometry.Point;
 
@@ -73,7 +72,7 @@ public class TreeCreateToolTest extends TreeToolTest {
 		TreeEditPart parent2 = addEditPart(parent, "parent2", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		UiUtils.expandAll(m_viewer.getTree());
+		expandAll(m_viewer);
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//
@@ -163,7 +162,7 @@ public class TreeCreateToolTest extends TreeToolTest {
 		addEditPart(parent, "parent1", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		UiUtils.expandAll(m_viewer.getTree());
+		expandAll(m_viewer);
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//
@@ -206,7 +205,7 @@ public class TreeCreateToolTest extends TreeToolTest {
 		addEditPart(parent, "parent1", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		UiUtils.expandAll(m_viewer.getTree());
+		expandAll(m_viewer);
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeDragToolTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeDragToolTest.java
@@ -57,7 +57,7 @@ public class TreeDragToolTest extends TreeToolTest {
 		TreeEditPart child1 = addEditPart(parent, "child1", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		m_viewer.expandAll();
+		expandAll(m_viewer);
 		//
 		Point location = getOnLocation(parent);
 		m_sender.doubleClick(location.x, location.y, 3);
@@ -100,11 +100,11 @@ public class TreeDragToolTest extends TreeToolTest {
 		TreeEditPart child3 = addEditPart(parent, "child3", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		m_viewer.expandAll();
+		expandAll(m_viewer);
 		//
 		m_viewer.select(child3);
 		//
-		DropTarget dropTarget = (DropTarget) m_viewer.getTree().getData("DropTarget");
+		DropTarget dropTarget = (DropTarget) m_viewer.getControl().getData("DropTarget");
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//
@@ -202,11 +202,11 @@ public class TreeDragToolTest extends TreeToolTest {
 		TreeEditPart child3 = addEditPart(parent, "child3", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		m_viewer.expandAll();
+		expandAll(m_viewer);
 		//
 		m_viewer.select(child3);
 		//
-		DropTarget dropTarget = (DropTarget) m_viewer.getTree().getData("DropTarget");
+		DropTarget dropTarget = (DropTarget) m_viewer.getControl().getData("DropTarget");
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//
@@ -250,11 +250,11 @@ public class TreeDragToolTest extends TreeToolTest {
 		TreeEditPart child3 = addEditPart(parent, "child3", actualLogger, ipolicy);
 		//
 		refreshTreeParst(parent);
-		m_viewer.expandAll();
+		expandAll(m_viewer);
 		//
 		m_viewer.select(child3);
 		//
-		DropTarget dropTarget = (DropTarget) m_viewer.getTree().getData("DropTarget");
+		DropTarget dropTarget = (DropTarget) m_viewer.getControl().getData("DropTarget");
 		//
 		RequestsLogger expectedLogger = new RequestsLogger();
 		//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeRobot.java
@@ -81,7 +81,7 @@ public final class TreeRobot {
 	 * Collapses all items.
 	 */
 	public TreeRobot collapseAll() {
-		m_viewer.collapseAll();
+		UiUtils.collapseAll(m_viewer.getControl());
 		waitEventLoop();
 		return this;
 	}
@@ -90,7 +90,7 @@ public final class TreeRobot {
 	 * Expands all items.
 	 */
 	public TreeRobot expandAll() {
-		m_viewer.expandAll();
+		UiUtils.expandAll(m_viewer.getControl());
 		waitEventLoop();
 		return this;
 	}
@@ -209,7 +209,7 @@ public final class TreeRobot {
 	}
 
 	private void notifyDropTarget(int eventType, Event event) {
-		DropTarget dropTarget = (DropTarget) m_viewer.getTree().getData("DropTarget");
+		DropTarget dropTarget = (DropTarget) m_viewer.getControl().getData("DropTarget");
 		dropTarget.notifyListeners(eventType, event);
 	}
 
@@ -459,7 +459,7 @@ public final class TreeRobot {
 	 * @return models of expanded {@link EditPart}s.
 	 */
 	private Object[] getExpandedElements() {
-		TreeItem[] expandedItems = UiUtils.getExpanded(m_viewer.getTree());
+		TreeItem[] expandedItems = UiUtils.getExpanded(m_viewer.getControl());
 		// prepare models
 		Object[] models = new Object[expandedItems.length];
 		for (int i = 0; i < expandedItems.length; i++) {
@@ -484,7 +484,7 @@ public final class TreeRobot {
 		}
 		// no insert
 		{
-			Tree tree = (Tree) m_viewer.getControl();
+			Tree tree = m_viewer.getControl();
 			Object item = tree.getData("_wbp_insertMarkItem");
 			assertNull(item);
 		}
@@ -506,7 +506,7 @@ public final class TreeRobot {
 	}
 
 	private List<TreeItem> getFeedbackSelection() {
-		Tree tree = (Tree) m_viewer.getControl();
+		Tree tree = m_viewer.getControl();
 		List<TreeItem> selectedItems = new ArrayList<>();
 		Collections.addAll(selectedItems, tree.getSelection());
 		for (EditPart selectedEditPart : m_viewer.getSelectedEditParts()) {
@@ -526,7 +526,7 @@ public final class TreeRobot {
 	}
 
 	private void assertFeedback_insert(Object object, boolean before) {
-		Tree tree = (Tree) m_viewer.getControl();
+		Tree tree = m_viewer.getControl();
 		TreeEditPart editPart = getEditPart(object);
 		// item
 		Object item = tree.getData("_wbp_insertMarkItem");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeToolTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/TreeToolTest.java
@@ -17,6 +17,7 @@ import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.tree.TreeEditPart;
 import org.eclipse.wb.gef.tree.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
+import org.eclipse.wb.internal.core.utils.ui.UiUtils;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 import org.eclipse.wb.internal.gef.tree.TreeViewer;
 
@@ -27,7 +28,6 @@ import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.requests.SelectionRequest;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -65,15 +65,8 @@ public abstract class TreeToolTest extends GefTestCase {
 			}
 		};
 		// create viewer
-		m_viewer = new TreeViewer(m_shell, SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI) {
-			@Override
-			public void expandAll() {
-				super.expandAll();
-				while (Display.getCurrent().readAndDispatch()) {
-					// draw expanded viewer
-				}
-			}
-		};
+		m_viewer = new TreeViewer();
+		m_viewer.createControl(m_shell);
 		m_viewer.getControl().setSize(500, 400);
 		m_viewer.setEditDomain(m_domain);
 		// create sender
@@ -160,6 +153,14 @@ public abstract class TreeToolTest extends GefTestCase {
 	protected static interface ILayoutEditPolicy {
 		boolean isGoodReferenceChild(Request request, EditPart editPart);
 	}
+
+	protected static final void expandAll(TreeViewer viewer) {
+		UiUtils.expandAll(viewer.getControl());
+		while (Display.getCurrent().readAndDispatch()) {
+			// draw expanded viewer
+		}
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// EditPart implementation


### PR DESCRIPTION
A TreeViewer should always be created with an empty constructor. The binding to the SWT tree is then done by calling `createControl()`.

Furthermore the following methods are removed:
- expandAll()
- collapseAll()
- getTree()