### PR TITLE
Use `isShowComplex()` when double-clicking on property

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/table/PropertyTable.java
@@ -581,7 +581,7 @@ public class PropertyTable extends ScrollingGraphicalViewer {
 					.getDoubleClickTime()) {
 				try {
 					if (m_activePropertyInfo != null) {
-						if (m_activePropertyInfo.isComplex()) {
+						if (m_activePropertyInfo.isShowComplex()) {
 							m_activePropertyInfo.flip();
 						} else {
 							Property property = m_activePropertyInfo.getProperty();


### PR DESCRIPTION
When using `isComplex()`, the property table attempts to flip a complex property, even though it doesn't contain any children. Due to how flipping is implemented, this then causes the property to lose its selection.

Using `isShowComplex()` avoids this problem.