### PR TITLE
Process deferred layout requests before taking screenshot #1324

### DIFF
--- a/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
+++ b/org.eclipse.wb.os/src/org/eclipse/wb/os/OSSupport.java
@@ -153,6 +153,9 @@ public abstract class OSSupport {
 	protected final Shell layoutShell(Control control) {
 		Shell shell = control.getShell();
 		doLayout(shell);
+		// Implicitly calls `runDeferredLayouts()`
+		// see https://github.com/eclipse-windowbuilder/windowbuilder/issues/1324
+		shell.getDisplay().readAndDispatch();
 		fixZeroSizes_begin(shell);
 		return shell;
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/ExpandableCompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/ExpandableCompositeTest.java
@@ -106,6 +106,9 @@ public class ExpandableCompositeTest extends AbstractFormsTest {
 						}
 					}
 				}""");
+		// When the "expanded" property is set, the "isLayoutDeferred()" property is set as well
+		// See https://github.com/eclipse-windowbuilder/windowbuilder/issues/1324
+		assertFalse(composite.getBounds().isEmpty(), "Layout not applied on ExpandableComposite");
 	}
 
 	/**


### PR DESCRIPTION
When the "expanded" property is set for an ExpandableComposite, the "isLayoutDeferred()" property is set as well.

This causes the layout to be done _after_ the screenshot has been taken, meaning that at that point it still has an empty size.
As a result, there is no image to show in the designer page.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1324