### PR TITLE
Mark IDesignPage.getProgressMonitor() for removal

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
@@ -455,6 +455,7 @@ public final class DesignPage implements IDesignPage {
 		final Display display = Display.getCurrent();
 		IRunnableWithProgress runnable = new IRunnableWithProgress() {
 			@Override
+			@SuppressWarnings("removal")
 			public void run(final IProgressMonitor monitor) throws InvocationTargetException,
 			InterruptedException {
 				monitor.beginTask("Opening Design page.", 7);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/IDesignPageSite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/IDesignPageSite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -74,7 +74,11 @@ public interface IDesignPageSite {
 		 * @return the {@link IProgressMonitor} to use for displaying progress during parsing (initiated
 		 *         by {@link IDesignPage}). If parsing was complete, or we run tests, then
 		 *         {@link NullProgressMonitor} will be returned. Never returns <code>null</code>.
+		 * @deprecated The progress monitor should never be used outside of the parsing
+		 *             context. This method will be removed after the 2028-release.
 		 */
+		@SuppressWarnings("removal")
+		@Deprecated(forRemoval = true, since = "2026-03")
 		public static IProgressMonitor getProgressMonitor() {
 			return DesignPageSite.getProgressMonitor();
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignPageSite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/DesignPageSite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2025 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -128,7 +128,9 @@ public abstract class DesignPageSite implements IDesignPageSite {
 	 * @return the {@link IProgressMonitor} to use for displaying progress during parsing (initiated
 	 *         by {@link IDesignPage}). If parsing was complete, or we run tests, then
 	 *         {@link NullProgressMonitor} will be returned. Never returns <code>null</code>.
+	 * @deprecated The progress monitor should never be used outside of the parsing context.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static IProgressMonitor getProgressMonitor() {
 		return m_progressMonitor != null ? m_progressMonitor : NULL_PROGRESS_MONITOR;
 	}
@@ -139,7 +141,9 @@ public abstract class DesignPageSite implements IDesignPageSite {
 	 *
 	 * @param progressMonitor
 	 *          the {@link IProgressMonitor} to use, may be <code>null</code>.
+	 * @deprecated The progress monitor should never be used outside of the parsing context.
 	 */
+	@Deprecated(forRemoval = true, since = "2026-03")
 	public static void setProgressMonitor(IProgressMonitor progressMonitor) {
 		m_progressMonitor = progressMonitor;
 	}


### PR DESCRIPTION
The progress monitor is only set during parsing and should not be used in a different context.