### PR TITLE
Compatibility with GEF 3.27.0

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/graphical/GraphicalViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -150,7 +150,8 @@ public class GraphicalViewer extends AbstractEditPartViewer implements org.eclip
 	 */
 	@Override
 	public EditPart findObjectAtExcluding(Point location,
-			final Collection<IFigure> exclude,
+			// TODO Draw2D - Typify once lower bound is 3.22
+			@SuppressWarnings("rawtypes") final Collection exclude,
 			final Conditional conditional) {
 		EditPart editPart = findObjectAtExcluding(location, exclude, conditional, MENU_PRIMARY_LAYER);
 		if (editPart == null) {

--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/internal/gef/tree/TreeViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,6 @@ import org.eclipse.wb.gef.tree.TreeEditPart;
 import org.eclipse.wb.internal.gef.core.AbstractEditPartViewer;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 
-import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -190,7 +189,8 @@ public class TreeViewer extends AbstractEditPartViewer {
 	 */
 	@Override
 	public EditPart findObjectAtExcluding(Point location,
-			Collection<IFigure> exclude,
+			// TODO Draw2D - Typify once lower bound is 3.22
+			@SuppressWarnings("rawtypes") Collection exclude,
 			Conditional conditional) {
 		// simple check location
 		Rectangle clientArea = m_tree.getClientArea();
@@ -217,7 +217,8 @@ public class TreeViewer extends AbstractEditPartViewer {
 
 	@Override
 	public EditPart findObjectAtExcluding(Point location,
-			Collection<IFigure> exclude,
+			// TODO Draw2D - Typify once lower bound is 3.22
+			@SuppressWarnings("rawtypes") Collection exclude,
 			Conditional conditional,
 			String layer) {
 		return null;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EmptyEditPartViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -55,7 +55,8 @@ public class EmptyEditPartViewer extends AbstractEditPartViewer implements IEdit
 
 	@Override
 	public EditPart findObjectAtExcluding(Point location,
-			Collection<IFigure> exclude,
+			// TODO Draw2D - Typify once lower bound is 3.22
+			@SuppressWarnings("rawtypes") Collection exclude,
 			Conditional conditional) {
 		return null;
 	}


### PR DESCRIPTION
The exclusion set in method `findObjectAtExcluding()` may be either edit parts (TreeViewer) or figures (GraphicalEditPart).