### PR TITLE
Use `EmbeddedSwingComposite` for `BorderPreviewCanvas`

### DIFF
--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing;singleton:=true
-Bundle-Version: 1.10.400.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -61,8 +61,6 @@ import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
 import javax.swing.border.Border;
-
-import swingintegration.example.EmbeddedSwingComposite2;
 
 /**
  * Dialog for {@link Border} editing.
@@ -193,11 +191,8 @@ public final class BorderDialog extends ResizableDialog {
 			GridDataFactory.create(previewGroup).spanH(2).grabH().fillH();
 			GridLayoutFactory.create(previewGroup);
 			previewGroup.setText(ModelMessages.BorderDialog_preview);
-			//
-			if (EmbeddedSwingComposite2.canUseAwt()) {
-				m_previewCanvas = new BorderPreviewCanvas(previewGroup, SWT.NONE);
-				GridDataFactory.create(m_previewCanvas).grab().fill().hintV(100);
-			}
+			m_previewCanvas = new BorderPreviewCanvas(previewGroup, SWT.NONE);
+			GridDataFactory.create(m_previewCanvas).grab().fill().hintV(100);
 		}
 		//
 		updateGUI();

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderPreviewCanvas.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/border/BorderPreviewCanvas.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,7 +28,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.LineBorder;
 
-import swingintegration.example.EmbeddedSwingComposite2;
+import swingintegration.example.EmbeddedSwingComposite;
 
 /**
  * {@link Composite} for displaying {@link Border}.
@@ -36,7 +36,7 @@ import swingintegration.example.EmbeddedSwingComposite2;
  * @author scheglov_ke
  * @coverage swing.property.editor
  */
-public final class BorderPreviewCanvas extends EmbeddedSwingComposite2 {
+public final class BorderPreviewCanvas extends EmbeddedSwingComposite {
 	private JPanel m_awtRoot;
 	private JPanel m_emptyPanel;
 	private JPanel m_filledPanel_1;


### PR DESCRIPTION
This replaces the JApplet-based `EmbeddedSwingComposite2` with the JRootPane-based `EmbeddedSwingComposite`. The JApplet class has been removed with Java 26 and we must therefore stop using it.