### PR TITLE
Deprecate CSpinner in favor of native SWT Spinner

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/CSpinner.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/CSpinner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -39,7 +39,10 @@ import java.text.ParseException;
  *
  * @author scheglov_ke
  * @coverage core.control
+ * @Deprecated Use the native {@link Spinner} directly. This class will be
+ *             removed after the 2028-03 release.
  */
+@Deprecated(since = "2026-03", forRemoval = true)
 public class CSpinner extends Composite {
 	private static final Color COLOR_VALID = Display.getCurrent().getSystemColor(
 			SWT.COLOR_LIST_BACKGROUND);
@@ -66,6 +69,7 @@ public class CSpinner extends Composite {
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Deprecated
 	public CSpinner(Composite parent, int style) {
 		super(parent, style);
 		m_button = new Button(this, SWT.ARROW | SWT.DOWN);
@@ -165,6 +169,7 @@ public class CSpinner extends Composite {
 	// Access
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Deprecated
 	@Override
 	public void setEnabled(boolean enabled) {
 		super.setEnabled(enabled);
@@ -177,6 +182,7 @@ public class CSpinner extends Composite {
 	 * <p>
 	 * See {@link Spinner#setDigits(int)}.
 	 */
+	@Deprecated
 	public void setDigits(int digits) {
 		m_formatPattern = "0.";
 		m_multiplier = 1;
@@ -191,6 +197,7 @@ public class CSpinner extends Composite {
 	/**
 	 * Sets minimum and maximum using single invocation.
 	 */
+	@Deprecated
 	public void setRange(int minimum, int maximum) {
 		setMinimum(minimum);
 		setMaximum(maximum);
@@ -199,6 +206,7 @@ public class CSpinner extends Composite {
 	/**
 	 * @return the minimum value that the receiver will allow.
 	 */
+	@Deprecated
 	public int getMinimum() {
 		return m_minimum;
 	}
@@ -206,6 +214,7 @@ public class CSpinner extends Composite {
 	/**
 	 * Sets the minimum value that the receiver will allow.
 	 */
+	@Deprecated
 	public void setMinimum(int minimum) {
 		m_minimum = minimum;
 		setSelection(Math.max(m_value, m_minimum));
@@ -214,6 +223,7 @@ public class CSpinner extends Composite {
 	/**
 	 * Sets the maximum value that the receiver will allow.
 	 */
+	@Deprecated
 	public void setMaximum(int maximum) {
 		m_maximum = maximum;
 		setSelection(Math.min(m_value, m_maximum));
@@ -223,6 +233,7 @@ public class CSpinner extends Composite {
 	 * Sets the amount that the receiver's value will be modified by when the up/down arrows are
 	 * pressed to the argument, which must be at least one.
 	 */
+	@Deprecated
 	public void setIncrement(int increment) {
 		m_increment = increment;
 	}
@@ -232,6 +243,7 @@ public class CSpinner extends Composite {
 	 * not within the range specified by minimum and maximum, it will be adjusted to fall within this
 	 * range.
 	 */
+	@Deprecated
 	public void setSelection(int newValue) {
 		newValue = Math.min(Math.max(m_minimum, newValue), m_maximum);
 		if (newValue != m_value || m_text.getText().length() == 0) {
@@ -251,6 +263,7 @@ public class CSpinner extends Composite {
 	/**
 	 * @return the <em>selection</em>, which is the receiver's position.
 	 */
+	@Deprecated
 	public int getSelection() {
 		return m_value;
 	}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/CSpinnerDeferredNotifier.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/CSpinnerDeferredNotifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,8 +13,6 @@
 package org.eclipse.wb.core.controls;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
 /**
@@ -23,52 +21,14 @@ import org.eclipse.swt.widgets.Listener;
  * @author scheglov_ke
  * @author lobas_av
  * @coverage core.control
+ * @deprecated Use {@link SpinnerDeferredNotifier} instead. This class will be
+ *             removed after the 2028-03 release.
  */
-public final class CSpinnerDeferredNotifier {
-	private final CSpinner m_spinner;
-	private final Display m_display;
-	private final int m_timeout;
-	private final Listener m_listener;
+@Deprecated(since = "2026-03", forRemoval = true)
+public final class CSpinnerDeferredNotifier extends SpinnerDeferredNotifier {
 
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Constructor
-	//
-	////////////////////////////////////////////////////////////////////////////
-	public CSpinnerDeferredNotifier(CSpinner spinner, int timeout, Listener listener) {
-		m_spinner = spinner;
-		m_display = m_spinner.getDisplay();
-		m_timeout = timeout;
-		m_listener = listener;
-		addListener();
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Listener
-	//
-	////////////////////////////////////////////////////////////////////////////
-	private final int[] m_eventId = new int[1];
-
-	/**
-	 * Handler for single {@link SWT#Selection} event.
-	 */
-	private void addListener() {
-		m_spinner.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(final Event event) {
-				m_eventId[0]++;
-				m_display.timerExec(m_timeout, new Runnable() {
-					int m_id = m_eventId[0];
-
-					@Override
-					public void run() {
-						if (m_id == m_eventId[0]) {
-							m_listener.handleEvent(event);
-						}
-					}
-				});
-			}
-		});
+	@Deprecated
+	public CSpinnerDeferredNotifier(@SuppressWarnings("removal") CSpinner spinner, int timeout, Listener listener) {
+		super(spinner, timeout, listener);
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/SpinnerDeferredNotifier.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/SpinnerDeferredNotifier.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Google, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.core.controls;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Spinner;
+
+/**
+ * Helper for sending single {@link SWT#Selection} event after some timeout.
+ *
+ * @author scheglov_ke
+ * @author lobas_av
+ * @coverage core.control
+ */
+@SuppressWarnings("removal")
+public sealed class SpinnerDeferredNotifier permits CSpinnerDeferredNotifier {
+	private final Control m_spinner;
+	private final Display m_display;
+	private final int m_timeout;
+	private final Listener m_listener;
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Constructor
+	//
+	////////////////////////////////////////////////////////////////////////////
+	public SpinnerDeferredNotifier(Spinner spinner, int timeout, Listener listener) {
+		m_spinner = spinner;
+		m_display = m_spinner.getDisplay();
+		m_timeout = timeout;
+		m_listener = listener;
+		addListener();
+	}
+
+	/* package */ SpinnerDeferredNotifier(CSpinner spinner, int timeout, Listener listener) {
+		m_spinner = spinner;
+		m_display = m_spinner.getDisplay();
+		m_timeout = timeout;
+		m_listener = listener;
+		addListener();
+	}
+
+	////////////////////////////////////////////////////////////////////////////
+	//
+	// Listener
+	//
+	////////////////////////////////////////////////////////////////////////////
+	private final int[] m_eventId = new int[1];
+
+	/**
+	 * Handler for single {@link SWT#Selection} event.
+	 */
+	private void addListener() {
+		m_spinner.addListener(SWT.Selection, new Listener() {
+			@Override
+			public void handleEvent(final Event event) {
+				m_eventId[0]++;
+				m_display.timerExec(m_timeout, new Runnable() {
+					int m_id = m_eventId[0];
+
+					@Override
+					public void run() {
+						if (m_id == m_eventId[0]) {
+							m_listener.handleEvent(event);
+						}
+					}
+				});
+			}
+		});
+	}
+}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/CSpinnerTest.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/test/CSpinnerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -34,10 +34,14 @@ import org.eclipse.swt.widgets.Text;
  *
  * @author scheglov_ke
  * @coverage core.test
+ * @deprecated Obsolete. This class will be removed after the 2028-03 release.
  */
+@Deprecated(since = "2026-03", forRemoval = true)
 public class CSpinnerTest {
+	@Deprecated
 	protected Shell shell;
 
+	@Deprecated
 	public static void main(String[] args) {
 		try {
 			CSpinnerTest window = new CSpinnerTest();
@@ -47,6 +51,7 @@ public class CSpinnerTest {
 		}
 	}
 
+	@Deprecated
 	public void open() {
 		final Display display = Display.getDefault();
 		createContents();
@@ -59,6 +64,8 @@ public class CSpinnerTest {
 		}
 	}
 
+	@Deprecated
+	@SuppressWarnings("removal")
 	protected void createContents() {
 		shell = new Shell();
 		shell.setSize(500, 375);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/actions/assistant/AbstractAssistantPage.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/editor/actions/assistant/AbstractAssistantPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.core.editor.actions.assistant;
 
-import org.eclipse.wb.core.controls.CSpinner;
-import org.eclipse.wb.core.controls.CSpinnerDeferredNotifier;
+import org.eclipse.wb.core.controls.SpinnerDeferredNotifier;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.property.Property;
@@ -35,6 +34,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 
 import org.apache.commons.lang3.StringUtils;
@@ -735,7 +735,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 	 * Adapter for <code>int</code> property.
 	 */
 	private final class IntegerPropertyInfo extends PropertyInfo {
-		private final CSpinner m_spinner;
+		private final Spinner m_spinner;
 		private final Listener m_listener = new Listener() {
 			@Override
 			public void handleEvent(Event event) {
@@ -750,10 +750,10 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 		// Constructor
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public IntegerPropertyInfo(String property, CSpinner spinner) {
+		public IntegerPropertyInfo(String property, Spinner spinner) {
 			super(property);
 			m_spinner = spinner;
-			new CSpinnerDeferredNotifier(m_spinner, 500, m_listener);
+			new SpinnerDeferredNotifier(m_spinner, 500, m_listener);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -787,7 +787,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 			int maxValue) {
 		new Label(parent, SWT.NONE).setText(title);
 		//
-		CSpinner spinner = new CSpinner(parent, SWT.BORDER);
+		Spinner spinner = new Spinner(parent, SWT.BORDER);
 		GridDataFactory.create(spinner).hintHC(10);
 		spinner.setMinimum(minValue);
 		spinner.setMaximum(maxValue);
@@ -873,7 +873,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 	 * Adapter for <code>double</code> property.
 	 */
 	private final class DoublePropertyInfo extends PropertyInfo {
-		private final CSpinner m_spinner;
+		private final Spinner m_spinner;
 		private final double m_multiplier;
 		private final Listener m_listener = new Listener() {
 			@Override
@@ -889,11 +889,11 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 		// Constructor
 		//
 		////////////////////////////////////////////////////////////////////////////
-		public DoublePropertyInfo(String property, CSpinner spinner, double multiplier) {
+		public DoublePropertyInfo(String property, Spinner spinner, double multiplier) {
 			super(property);
 			m_spinner = spinner;
 			m_multiplier = multiplier;
-			new CSpinnerDeferredNotifier(m_spinner, 500, m_listener);
+			new SpinnerDeferredNotifier(m_spinner, 500, m_listener);
 		}
 
 		////////////////////////////////////////////////////////////////////////////
@@ -929,7 +929,7 @@ public abstract class AbstractAssistantPage extends Composite implements ILayout
 		int multiplier = (int) Math.pow(10, digits);
 		new Label(parent, SWT.NONE).setText(title);
 		//
-		CSpinner spinner = new CSpinner(parent, SWT.BORDER);
+		Spinner spinner = new Spinner(parent, SWT.BORDER);
 		GridDataFactory.create(spinner).hintHC(10);
 		spinner.setMinimum((int) (minValue * multiplier));
 		spinner.setMaximum((int) (maxValue * multiplier));

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/geometry/AbstractGeometryDialog.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/editor/geometry/AbstractGeometryDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.model.property.editor.geometry;
 
-import org.eclipse.wb.core.controls.CSpinner;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.model.ModelMessages;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -28,6 +27,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Spinner;
 
 import java.lang.reflect.Field;
 
@@ -113,7 +113,7 @@ public abstract class AbstractGeometryDialog extends Dialog {
 		}
 		// spinner
 		{
-			final CSpinner spinner = new CSpinner(m_area, SWT.BORDER);
+			final Spinner spinner = new Spinner(m_area, SWT.BORDER);
 			GridDataFactory.create(spinner).hintHC(8).grabH().fillH();
 			spinner.setMinimum(0);
 			spinner.setMaximum(Integer.MAX_VALUE);

--- a/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutSpacesPage.java
+++ b/org.eclipse.wb.layout.group/src/org/eclipse/wb/internal/layout/group/model/assistant/GroupLayoutSpacesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.layout.group.model.assistant;
 
-import org.eclipse.wb.core.controls.CSpinner;
-import org.eclipse.wb.core.controls.CSpinnerDeferredNotifier;
+import org.eclipse.wb.core.controls.SpinnerDeferredNotifier;
 import org.eclipse.wb.core.editor.actions.assistant.ILayoutAssistantPage;
 import org.eclipse.wb.core.model.AbstractComponentInfo;
 import org.eclipse.wb.core.model.JavaInfo;
@@ -41,6 +40,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 
@@ -125,15 +125,15 @@ LayoutConstants {
 	// UI creation helpers
 	//
 	////////////////////////////////////////////////////////////////////////////
-	private CSpinner createSpinner(Composite componentComposite) {
-		CSpinner spinner = new CSpinner(componentComposite, SWT.BORDER);
+	private Spinner createSpinner(Composite componentComposite) {
+		Spinner spinner = new Spinner(componentComposite, SWT.BORDER);
 		GridDataFactory.create(spinner).hintHC(7);
 		spinner.setMaximum(Short.MAX_VALUE);
 		return spinner;
 	}
 
-	private void createSpinnerNotifier(CSpinner spinner, Listener listener) {
-		new CSpinnerDeferredNotifier(spinner, 500, listener);
+	private void createSpinnerNotifier(Spinner spinner, Listener listener) {
+		new SpinnerDeferredNotifier(spinner, 500, listener);
 	}
 
 	/**
@@ -178,8 +178,8 @@ LayoutConstants {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private final class ComponentComposite extends Composite {
-		private CSpinner m_widthSpinner;
-		private CSpinner m_heightSpinner;
+		private Spinner m_widthSpinner;
+		private Spinner m_heightSpinner;
 		private ToolBarManager m_verticalAnchorsManager;
 		private ToolBarManager m_horizontalAnchorsManager;
 
@@ -254,7 +254,7 @@ LayoutConstants {
 		@Override
 		public void handleEvent(Event event) {
 			if (event.type == SWT.Selection && event.doit) {
-				CSpinner spinner = (CSpinner) event.widget;
+				Spinner spinner = (Spinner) event.widget;
 				final int value = spinner.getSelection();
 				if (value > 0) {
 					setComponentSize(m_dimension, value);
@@ -268,7 +268,7 @@ LayoutConstants {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private final class SpaceComposite extends Composite {
-		private final CSpinner m_spinner;
+		private final Spinner m_spinner;
 		private final Button m_button;
 		private final int m_direction;
 		private final int m_dimension;
@@ -307,15 +307,15 @@ LayoutConstants {
 			createSpinnerNotifier(m_spinner, new Listener() {
 				@Override
 				public void handleEvent(Event event) {
-					if (event.type == SWT.Selection && event.doit) {
-						int gapValue = m_spinner.getSelection();
-						int defaultGapSize =
-								m_anchorsSupport.getDefaultGapSize(m_javaInfo, m_dimension, m_direction).intValue();
-						if (gapValue < 1 || gapValue == defaultGapSize) {
-							gapValue = NOT_EXPLICITLY_DEFINED;
-						}
-						setGapValue(gapValue);
+				if (event.type == SWT.Selection && event.doit) {
+					int gapValue = m_spinner.getSelection();
+					int defaultGapSize =
+							m_anchorsSupport.getDefaultGapSize(m_javaInfo, m_dimension, m_direction).intValue();
+					if (gapValue < 1 || gapValue == defaultGapSize) {
+						gapValue = NOT_EXPLICITLY_DEFINED;
 					}
+					setGapValue(gapValue);
+				}
 				}
 			});
 		}
@@ -352,9 +352,9 @@ LayoutConstants {
 				@Override
 				public void run() throws Exception {
 					m_anchorsSupport.action_setEmptySpaceProperties(
-							m_javaInfo,
-							m_dimension,
-							m_direction,
+					m_javaInfo,
+					m_dimension,
+					m_direction,
 							gapValue);
 				}
 			});

--- a/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.MigLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.MigLayout;singleton:=true
-Bundle-Version: 1.11.300.qualifier
+Bundle-Version: 1.12.0.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.MigLayout.Activator
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/ui/DimensionResizeComposite.java
+++ b/org.eclipse.wb.swing.MigLayout/src/org/eclipse/wb/internal/swing/MigLayout/model/ui/DimensionResizeComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.MigLayout.model.ui;
 
-import org.eclipse.wb.core.controls.CSpinner;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
@@ -24,6 +23,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Spinner;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,10 +43,10 @@ public final class DimensionResizeComposite extends Composite {
 	// UI
 	private final Button m_defaultWeightButton;
 	private final Button m_customWeightButton;
-	private final CSpinner m_weightSpinner;
+	private final Spinner m_weightSpinner;
 	private final Button m_defaultPriorityButton;
 	private final Button m_customPriorityButton;
-	private final CSpinner m_prioritySpinner;
+	private final Spinner m_prioritySpinner;
 	// listener
 	private boolean m_updatingDimension;
 
@@ -100,9 +100,10 @@ public final class DimensionResizeComposite extends Composite {
 					}
 				});
 				//
-				m_weightSpinner = new CSpinner(weightComposite, SWT.BORDER);
+				m_weightSpinner = new Spinner(weightComposite, SWT.BORDER);
 				GridDataFactory.create(m_weightSpinner).hintHC(10).grabH().fill();
-				m_weightSpinner.setRange(0, Integer.MAX_VALUE);
+				m_weightSpinner.setMinimum(0);
+				m_weightSpinner.setMaximum(Integer.MAX_VALUE);
 				m_weightSpinner.addListener(SWT.Selection, new Listener() {
 					@Override
 					public void handleEvent(Event event) {
@@ -143,9 +144,10 @@ public final class DimensionResizeComposite extends Composite {
 					}
 				});
 				//
-				m_prioritySpinner = new CSpinner(priorityComposite, SWT.BORDER);
+				m_prioritySpinner = new Spinner(priorityComposite, SWT.BORDER);
 				GridDataFactory.create(m_prioritySpinner).hintHC(10).grabH().fill();
-				m_prioritySpinner.setRange(0, Integer.MAX_VALUE);
+				m_prioritySpinner.setMinimum(0);
+				m_prioritySpinner.setMaximum(Integer.MAX_VALUE);
 				m_prioritySpinner.addListener(SWT.Selection, new Listener() {
 					@Override
 					public void handleEvent(Event event) {

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/ui/DimensionEditDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/gbl/ui/DimensionEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.layout.gbl.ui;
 
-import org.eclipse.wb.core.controls.CSpinner;
 import org.eclipse.wb.core.controls.Separator;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
@@ -39,6 +38,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 
 import java.text.MessageFormat;
@@ -102,11 +102,11 @@ ResizableDialog {
 	// alignment
 	private List<Button> m_alignmentButtons;
 	// size
-	private CSpinner m_sizeSpinner;
+	private Spinner m_sizeSpinner;
 	// grow
 	private Button m_noGrowButton;
 	private Button m_growButton;
-	private CSpinner m_growSpinner;
+	private Spinner m_growSpinner;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -307,7 +307,7 @@ ResizableDialog {
 				label.setText(ModelMessages.DimensionEditDialog_minimum);
 			}
 			{
-				m_sizeSpinner = new CSpinner(composite, SWT.BORDER);
+				m_sizeSpinner = new Spinner(composite, SWT.BORDER);
 				GridDataFactory.create(m_sizeSpinner).hintHC(15);
 				m_sizeSpinner.setMinimum(0);
 				m_sizeSpinner.setMaximum(Integer.MAX_VALUE);
@@ -355,7 +355,7 @@ ResizableDialog {
 				}
 			});
 			//
-			m_growSpinner = new CSpinner(composite, SWT.BORDER);
+			m_growSpinner = new Spinner(composite, SWT.BORDER);
 			GridDataFactory.create(m_growSpinner).hintHC(15);
 			m_growSpinner.addListener(SWT.Selection, new Listener() {
 				@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/font/DerivedFontPage.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/font/DerivedFontPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.font;
 
-import org.eclipse.wb.core.controls.CSpinner;
 import org.eclipse.wb.core.controls.Separator;
 import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.internal.core.model.property.GenericProperty;
@@ -28,6 +27,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Spinner;
 
 import java.awt.Component;
 import java.awt.Font;
@@ -50,8 +50,8 @@ public final class DerivedFontPage extends AbstractFontPage {
 	private final Button m_italicClear;
 	private final Button m_relativeButton;
 	private final Button m_absoluteButton;
-	private final CSpinner m_relativeSpinner;
-	private final CSpinner m_absoluteSpinner;
+	private final Spinner m_relativeSpinner;
+	private final Spinner m_absoluteSpinner;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -160,10 +160,11 @@ public final class DerivedFontPage extends AbstractFontPage {
 					GridDataFactory.create(m_relativeButton).indentHC(2).hintHC(15);
 				}
 				{
-					m_relativeSpinner = new CSpinner(composite, SWT.BORDER);
+					m_relativeSpinner = new Spinner(composite, SWT.BORDER);
 					GridDataFactory.create(m_relativeSpinner).hintHC(15);
 					m_relativeSpinner.addListener(SWT.Selection, listener);
-					m_relativeSpinner.setRange(Integer.MIN_VALUE, Integer.MAX_VALUE);
+					m_relativeSpinner.setMinimum(Integer.MIN_VALUE);
+					m_relativeSpinner.setMaximum(Integer.MAX_VALUE);
 				}
 			}
 			// absolute
@@ -174,10 +175,11 @@ public final class DerivedFontPage extends AbstractFontPage {
 					GridDataFactory.create(m_absoluteButton).indentHC(2).hintHC(15);
 				}
 				{
-					m_absoluteSpinner = new CSpinner(composite, SWT.BORDER);
+					m_absoluteSpinner = new Spinner(composite, SWT.BORDER);
 					GridDataFactory.create(m_absoluteSpinner).hintHC(15);
 					m_absoluteSpinner.addListener(SWT.Selection, listener);
-					m_absoluteSpinner.setRange(0, Integer.MAX_VALUE);
+					m_relativeSpinner.setMinimum(0);
+					m_relativeSpinner.setMaximum(Integer.MAX_VALUE);
 				}
 			}
 		}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/table/TableModelDialog.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/models/table/TableModelDialog.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.model.property.editor.models.table;
 
-import org.eclipse.wb.core.controls.CSpinner;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.utils.ui.GridDataFactory;
 import org.eclipse.wb.internal.core.utils.ui.GridLayoutFactory;
@@ -29,6 +28,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
@@ -89,13 +89,13 @@ public final class TableModelDialog extends ResizableDialog {
 	private TitledComposite m_columnPropertiesComposite;
 	private TableModelPreviewCanvas m_swingComposite;
 	// columns
-	private CSpinner m_columnCountSpinner;
+	private Spinner m_columnCountSpinner;
 	private Button m_insertColumnButton;
 	private Button m_deleteColumnButton;
 	private Button m_moveColumnLeftButton;
 	private Button m_moveColumnRightButton;
 	// rows
-	private CSpinner m_rowCountSpinner;
+	private Spinner m_rowCountSpinner;
 	private Button m_insertRowButton;
 	private Button m_deleteRowButton;
 	private Button m_moveRowUpButton;
@@ -109,9 +109,9 @@ public final class TableModelDialog extends ResizableDialog {
 	private Label m_columnPropertyValuesLabel;
 	private Text m_columnPropertyValues;
 	private Button m_columnPropertyValuesEdit;
-	private CSpinner m_columnPropertyPrefWidth;
-	private CSpinner m_columnPropertyMinWidth;
-	private CSpinner m_columnPropertyMaxWidth;
+	private Spinner m_columnPropertyPrefWidth;
+	private Spinner m_columnPropertyMinWidth;
+	private Spinner m_columnPropertyMaxWidth;
 
 	@Override
 	protected Control createDialogArea(Composite parent) {
@@ -161,7 +161,7 @@ public final class TableModelDialog extends ResizableDialog {
 		// Count
 		{
 			new Label(container, SWT.NONE).setText(ModelMessages.TableModelDialog_columnsCount);
-			m_columnCountSpinner = new CSpinner(container, SWT.BORDER);
+			m_columnCountSpinner = new Spinner(container, SWT.BORDER);
 			GridDataFactory.create(m_columnCountSpinner).grabH().fillH().hintHC(5);
 			m_swingComposite.addJTableOperationSelectionListener(m_columnCountSpinner, new TableOperationRunnable() {
 				@Override
@@ -253,7 +253,7 @@ public final class TableModelDialog extends ResizableDialog {
 		// Count
 		{
 			new Label(container, SWT.NONE).setText(ModelMessages.TableModelDialog_rowsCount);
-			m_rowCountSpinner = new CSpinner(container, SWT.BORDER);
+			m_rowCountSpinner = new Spinner(container, SWT.BORDER);
 			GridDataFactory.create(m_rowCountSpinner).grabH().fillH().hintHC(5);
 			m_swingComposite.addJTableOperationSelectionListener(m_rowCountSpinner, new TableOperationRunnable() {
 				@Override
@@ -368,9 +368,10 @@ public final class TableModelDialog extends ResizableDialog {
 		{
 			new Label(container, SWT.NONE).setText(
 					ModelMessages.TableModelDialog_columnPropertiesPrefWidth);
-			m_columnPropertyPrefWidth = new CSpinner(container, SWT.BORDER);
+			m_columnPropertyPrefWidth = new Spinner(container, SWT.BORDER);
 			GridDataFactory.create(m_columnPropertyPrefWidth).hintHC(15);
-			m_columnPropertyPrefWidth.setRange(0, Integer.MAX_VALUE);
+			m_columnPropertyPrefWidth.setMinimum(0);
+			m_columnPropertyPrefWidth.setMaximum(Integer.MAX_VALUE);
 			m_swingComposite.addJTableOperationSelectionListener(m_columnPropertyPrefWidth, new TableOperationRunnable() {
 				@Override
 				public void run(int row, int column) {
@@ -429,9 +430,10 @@ public final class TableModelDialog extends ResizableDialog {
 		{
 			new Label(container, SWT.NONE).setText(
 					ModelMessages.TableModelDialog_columnPropertiesMinWidth);
-			m_columnPropertyMinWidth = new CSpinner(container, SWT.BORDER);
+			m_columnPropertyMinWidth = new Spinner(container, SWT.BORDER);
 			GridDataFactory.create(m_columnPropertyMinWidth).hintHC(15);
-			m_columnPropertyMinWidth.setRange(0, Integer.MAX_VALUE);
+			m_columnPropertyMinWidth.setMinimum(0);
+			m_columnPropertyMinWidth.setMaximum(Integer.MAX_VALUE);
 			m_swingComposite.addJTableOperationSelectionListener(m_columnPropertyMinWidth, new TableOperationRunnable() {
 				@Override
 				public void run(int row, int column) {
@@ -479,9 +481,10 @@ public final class TableModelDialog extends ResizableDialog {
 		{
 			new Label(container, SWT.NONE).setText(
 					ModelMessages.TableModelDialog_columnPropertiesMaxWidth);
-			m_columnPropertyMaxWidth = new CSpinner(container, SWT.BORDER);
+			m_columnPropertyMaxWidth = new Spinner(container, SWT.BORDER);
 			GridDataFactory.create(m_columnPropertyMaxWidth).hintHC(15);
-			m_columnPropertyMaxWidth.setRange(0, Integer.MAX_VALUE);
+			m_columnPropertyMaxWidth.setMinimum(0);
+			m_columnPropertyMaxWidth.setMaximum(Integer.MAX_VALUE);
 			m_swingComposite.addJTableOperationSelectionListener(m_columnPropertyMaxWidth, new TableOperationRunnable() {
 				@Override
 				public void run(int row, int column) {


### PR DESCRIPTION
The CSpinner is not properly rendered on Linux. There is no real benefit for maintaining our own implementation, so we should just go back to the one provided by SWT.