### PR TITLE
Don't log expected exceptions

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/DesignerPlugin.java
@@ -291,8 +291,8 @@ public class DesignerPlugin extends AbstractUIPlugin {
 	 */
 	public static void log(Throwable e) {
 		// print on console for easy debugging
-		if (m_displayExceptionOnConsole) {
-			e.printStackTrace();
+		if (!m_displayExceptionOnConsole) {
+			return;
 		}
 		// log into Eclipse .log
 		{


### PR DESCRIPTION
Some tests deliberately throw an exception. These exceptions are expected and should not show up in the build log. Logging can already be disabled by calling `setDisplayExceptionOnConsole(...)`. If disabled, this flag will now prevent any propagation to the console.