### PR TITLE
Remove obsolete clearSwingTree(...) method

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ContainerInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/ContainerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -60,7 +60,6 @@ import org.eclipse.wb.internal.swing.model.layout.LayoutInfo;
 import org.eclipse.wb.internal.swing.model.layout.absolute.AbsoluteLayoutCreationSupport;
 import org.eclipse.wb.internal.swing.model.layout.absolute.AbsoluteLayoutInfo;
 import org.eclipse.wb.internal.swing.model.property.TabOrderProperty;
-import org.eclipse.wb.internal.swing.utils.SwingUtils;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.draw2d.geometry.Insets;
@@ -250,15 +249,10 @@ public class ContainerInfo extends ComponentInfo {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void refresh_dispose() throws Exception {
-		// remember Container instance, we need it for clearSwingTree(), but "super" set object to "null"
-		Container container = (Container) getObject();
 		// inherit parent layout, if it is valid at all and valid time
 		processInitialLayout();
 		// call "super"
 		super.refresh_dispose();
-		if (isSwingRoot()) {
-			SwingUtils.clearSwingTree(container);
-		}
 	}
 
 	@Override

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Synchronizer;
 
 import java.awt.Component;
-import java.awt.Container;
 import java.awt.EventQueue;
 import java.awt.IllegalComponentStateException;
 import java.awt.Point;
@@ -37,9 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
-import javax.swing.text.JTextComponent;
 
 /**
  * Various utilities to operate with Swing.
@@ -260,44 +257,6 @@ public final class SwingUtils {
 		synchronized (Device.class) {
 			ReflectionUtils.setField(display, "synchronizer", newSynchronizer);
 		}
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Clean up
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * For unknown reason, when we have {@link Display} created and add any {@link JTextComponent}
-	 * sub-class to {@link JFrame}, we see {@link JFrame} in <code>[JNI global]</code> roots until we
-	 * dispose {@link Display} (until OleUninitialize() invocation). So, we clear all
-	 * {@link Container}'s to minimize number of components referenced from {@link JFrame}.
-	 * <p>
-	 * See also https://bugs.eclipse.org/bugs/show_bug.cgi?id=127374 and
-	 * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6407026
-	 * <p>
-	 * I found also that in Java6 {@link JFrame} may stuck somewhere in Draw2D/DirectDraw, so we
-	 * should clear not only for text components, but even when we make Swing screen shot.
-	 */
-	public static void clearSwingTree(final Container container) throws Exception {
-		runLaterAndWait(() -> {
-			if (container != null) {
-				// even if this container can not be effectively cleared, we will clear children,
-				// so minimize potential memory as much as possible
-				for (Component child : container.getComponents()) {
-					if (child instanceof Container) {
-						clearSwingTree((Container) child);
-					}
-				}
-				// remove all children Component's
-				ExecutionUtils.runIgnore(() -> container.removeAll());
-				// "tab order" property may install our FocusTraversalOnArray, so clear it
-				container.setFocusTraversalPolicy(null);
-				// remove layout manager: under JVM < 1.5 JFrame.setLayout() throws exception that
-				// JFrame.getContentPane().setLayout() should be used, so do this safely
-				ExecutionUtils.runIgnore(() -> container.setLayout(null));
-			}
-		});
 	}
 
 	////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This method was added to minimize the impact of a memory leak when creating calling `OleInitialize` from the SWT UI thread on Windows. According to the Oracle ticket, this issue has been fixed in 2011 and the problem can't be reproduce with the attached snippet.

The problem with this method is that it is a Swing done as a blocking operation from the SWT UI thread and can therefore lead to a deadlock on Linux, if the AWT Event Dispatcher thread requires exclusive UI access (e.g. when updating the LookAndFeel).

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1445

See:
https://bugreport.java.com/bugdatabase/JDK-6407026 https://bugs.eclipse.org/bugs/show_bug.cgi?id=127374