### PR TITLE
[GTK] Use factory pattern to create GtkWindow/GtkWidget instances

### DIFF
--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/GtkWidget.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/GtkWidget.java
@@ -26,11 +26,7 @@ import java.util.Objects;
 public class GtkWidget {
 	private final MemorySegment segment;
 
-	public GtkWidget(Widget widget) {
-		this(getHandle(widget));
-	}
-
-	public GtkWidget(long handle) {
+	protected GtkWidget(long handle) {
 		segment = handle == 0L ? MemorySegment.NULL : MemorySegment.ofAddress(handle);
 	}
 
@@ -52,9 +48,18 @@ public class GtkWidget {
 	}
 
 	/**
+	 * @param widget The SWT widget to create this object from.
+	 * @return A new {@link GtkWidget} instance backed by the given {@link Widget}
+	 *         handle.
+	 */
+	public static GtkWidget from(Widget widget) {
+		return new GtkWidget(getHandle(widget));
+	}
+
+	/**
 	 * @return the handle value of the {@link Widget} using reflection.
 	 */
-	private static long getHandle(Widget widget) {
+	protected static long getHandle(Widget widget) {
 		long widgetHandle = getHandleValue(widget, "fixedHandle");
 		if (widgetHandle == 0) {
 			// may be null, roll back to "handle"

--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -66,7 +66,7 @@ public final class OSSupportLinux extends OSSupport {
 		// setup key title to be used by compiz WM (if enabled)
 		if (!isWorkaroundsDisabled()) {
 			// prepare
-			GTK3.gtk_widget_show_now(new GtkWidget(shell));
+			GTK3.gtk_widget_show_now(GtkWidget.from(shell));
 			try {
 				Version currentVersion = FrameworkUtil.getBundle(SWT.class).getVersion();
 				// Bug/feature is SWT: since the widget is already shown, the Shell.setVisible()
@@ -85,7 +85,7 @@ public final class OSSupportLinux extends OSSupport {
 			m_eclipseShell = DesignerPlugin.getShell();
 			// sometimes can be null, don't know why.
 			if (m_eclipseShell != null) {
-				GTK3.gtk_window_set_keep_above(new GtkWindow(m_eclipseShell), true);
+				GTK3.gtk_window_set_keep_above(GtkWindow.from(m_eclipseShell), true);
 			}
 		}
 		shell.setLocation(10000, 10000);
@@ -98,9 +98,9 @@ public final class OSSupportLinux extends OSSupport {
 		super.endShot(control);
 		Shell shell = control.getShell();
 		if (!isWorkaroundsDisabled()) {
-			GTK.gtk_widget_hide(new GtkWidget(shell));
+			GTK.gtk_widget_hide(GtkWidget.from(shell));
 			if (m_eclipseShell != null) {
-				GTK3.gtk_window_set_keep_above(new GtkWindow(m_eclipseShell), false);
+				GTK3.gtk_window_set_keep_above(GtkWindow.from(m_eclipseShell), false);
 			}
 		}
 	}
@@ -202,7 +202,7 @@ public final class OSSupportLinux extends OSSupport {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	public static Rectangle getWidgetBounds(Widget w) {
-		GtkWidget widget = new GtkWidget(w);
+		GtkWidget widget = GtkWidget.from(w);
 		try (Arena arena = Arena.ofConfined()) {
 			GtkAllocation allocation = new GtkAllocation(arena);
 			GTK.gtk_widget_get_allocation(widget, allocation);

--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/ScreenshotMaker.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/ScreenshotMaker.java
@@ -91,7 +91,7 @@ public abstract class ScreenshotMaker {
 	 * fills {@code m_needsImage}.
 	 */
 	private void registerByHandle(Control control) {
-		GtkWidget widget = new GtkWidget(control);
+		GtkWidget widget = GtkWidget.from(control);
 		if (widget.segment() != MemorySegment.NULL) {
 			m_controlsRegistry.put(widget, control);
 		}

--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/gtk3/GTK3ScreenshotMaker.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/gtk3/GTK3ScreenshotMaker.java
@@ -45,7 +45,7 @@ public class GTK3ScreenshotMaker extends ScreenshotMaker {
 	}
 
 	private Image traverse(Widget widget, BiConsumer<GtkWidget, Image> callback) {
-		Image image = getImageSurface(new GtkWidget(widget), callback);
+		Image image = getImageSurface(GtkWidget.from(widget), callback);
 		if (image == null) {
 			return null;
 		}

--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/gtk3/GtkWindow.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/gtk3/GtkWindow.java
@@ -14,7 +14,7 @@ package org.eclipse.wb.internal.os.linux.gtk3;
 
 import org.eclipse.wb.internal.os.linux.GtkWidget;
 
-import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Widget;
 
 /**
  * A GtkWindow is a toplevel window which can contain other widgets. Windows
@@ -22,7 +22,16 @@ import org.eclipse.swt.widgets.Shell;
  * and allow the user to manipulate the window (resize it, move it, close it,…).
  */
 public class GtkWindow extends GtkWidget {
-	public GtkWindow(Shell shell) {
-		super(shell);
+	protected GtkWindow(long handle) {
+		super(handle);
+	}
+
+	/**
+	 * @param widget The SWT widget to create this object from.
+	 * @return A new {@link GtkWidget} instance backed by the given {@link Widget}
+	 *         handle.
+	 */
+	public static GtkWindow from(Widget widget) {
+		return new GtkWindow(getHandle(widget));
 	}
 }


### PR DESCRIPTION
Instances of those classes have to be created via the static `from` method, rather than the constructor. This decouples the SWT logic from "our" widget containers and may fix the sporadic NoClassDefFoundErrors seen during the Java 25 Linux tests.