### PR TITLE
Reactivate TableTest.test_TableColumn

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/TableTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/TableTest.java
@@ -32,7 +32,6 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -183,13 +182,12 @@ public class TableTest extends RcpModelTest {
 	 * In SWT Cocoa and Linux GTK, the column headers are excluded from the client
 	 * area, hence why we have to adjust them for the tests.
 	 */
-	// Disabled because of https://github.com/eclipse-windowbuilder/windowbuilder/issues/389
-	@Disabled
 	@Test
 	public void test_TableColumn() throws Exception {
 		CompositeInfo shell = parseComposite("""
-				class Test extends Shell {
-					public Test() {
+				class Test extends Composite {
+					public Test(Composite parent, int style) {
+						super(parent, style);
 						setLayout(new FillLayout());
 						Table table = new Table(this, SWT.BORDER);
 						table.setHeaderVisible(true);


### PR DESCRIPTION
Reactivate TableTest.test_TableColumn

The test fails on Linux when running with Xvnc. Underlying reason seems to be that tree columns behave differently on Linux than on Windows.

When `setHeaderVisible(true)` is called and the shell is opened, the table column will take up the entire width of the shell, ignoring the values passed to `tableColumn.setWidth(...)`. On Linux this corresponds to the methods:

- gtk_tree_view_column_get_fixed_width
- gtk_tree_view_column_get_width

Within this test, the second method is called because the shell is made visible for a short period while taking the screenshot, which internally causes `gtk_size_allocate` to be called. Given that this issue doesn't appear when executing the test locally, this seems to be a problem with the virtual desktop.

To avoid this problem, the test is no longer done with a shell, but a plain composite.