### PR TITLE
Cleanup and enable ResourceManager tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestNoManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestNoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.rcp.ToolkitProvider;
 import org.eclipse.wb.internal.swt.model.property.editor.image.ImageDescriptorPropertyEditor;
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -106,10 +107,11 @@ public class ImageDescriptorPropertyEditorTestNoManager extends ImageDescriptorP
 	 */
 	@Test
 	public void test_textSource_image_over_classpath() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				getInvocationSource("getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource("getClass()", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource("{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	/**
@@ -118,9 +120,10 @@ public class ImageDescriptorPropertyEditorTestNoManager extends ImageDescriptorP
 	 */
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				getInvocationSource("String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource("String.class", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource("{wbp_classTop}", "\"/Test.png\""));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestWithManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImageDescriptorPropertyEditorTestWithManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.rcp.ToolkitProvider;
 import org.eclipse.wb.internal.swt.model.property.editor.image.ImageDescriptorPropertyEditor;
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -106,10 +107,11 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	 */
 	@Test
 	public void test_textSource_image_over_classpath() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				getInvocationSource("getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource("getClass()", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource("{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	/**
@@ -118,10 +120,11 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	 */
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				getInvocationSource("String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource("String.class", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource("{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -151,10 +154,11 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	 */
 	@Test
 	public void test_textSource_image_over_classpath2() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				getInvocationSource("getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource("getClass()", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource("{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	/**
@@ -163,9 +167,10 @@ public class ImageDescriptorPropertyEditorTestWithManager extends ImageDescripto
 	 */
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass2() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				getInvocationSource("String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource("{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource("String.class", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource("{wbp_classTop}", "\"/Test.png\""));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestNoManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestNoManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,13 +16,13 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.rcp.ToolkitProvider;
 import org.eclipse.wb.internal.swt.model.property.editor.image.ImagePropertyEditor;
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
 import org.eclipse.jface.resource.LocalResourceManager;
 
 import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -97,24 +97,29 @@ public class ImagePropertyEditorTestNoManager extends ImagePropertyEditorTest {
 	/**
 	 * Image creation using constructor with input stream (over class resource).
 	 */
-	@Disabled
 	@Test
 	public void test_textSource_image_over_classpath() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				"new Image(null, getClass().getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))",
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"new org.eclipse.swt.graphics.Image(null, {wbp_classTop}.getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))");
+				"new Image(null, getClass().getResourceAsStream(\"/Test.png\"))",
+				"Classpath: /Test.png",
+				"new org.eclipse.swt.graphics.Image(null, {wbp_classTop}.getResourceAsStream(\"/Test.png\"))");
 	}
 
 	/**
 	 * Image creation using constructor with input stream (over class resource).
 	 */
-	@Disabled
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
+		setFileContentSrc("test", "OtherClass.java", """
+				package test;
+				public class OtherClass {}
+				""");
+		waitForAutoBuild();
 		assert_getText_getClipboardSource_forSource(
-				"new Image(null, java.lang.String.class.getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))",
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				"new org.eclipse.swt.graphics.Image(null, {wbp_classTop}.getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))");
+				"new Image(null, OtherClass.class.getResourceAsStream(\"/Test.png\"))",
+				"Classpath: /Test.png",
+				"new org.eclipse.swt.graphics.Image(null, {wbp_classTop}.getResourceAsStream(\"/Test.png\"))");
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestWithManager.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ImagePropertyEditorTestWithManager.java
@@ -20,13 +20,13 @@ import org.eclipse.wb.internal.swt.model.jface.resource.ManagerContainerInfo;
 import org.eclipse.wb.internal.swt.model.property.editor.image.ImagePropertyEditor;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.preferences.IPreferenceConstants;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.tests.common.GenericPropertyNoValue;
 
 import org.eclipse.jface.resource.LocalResourceManager;
 
 import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -103,25 +103,29 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	/**
 	 * Image creation using constructor with input stream (over class resource).
 	 */
-	@Disabled
 	@Test
 	public void test_textSource_image_over_classpath() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		assert_getText_getClipboardSource_forSource(
-				"new Image(null, getClass().getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))",
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource(shell(), "{wbp_classTop}", "/javax/swing/plaf/basic/icons/JavaCup16.png"));
+				"new Image(null, getClass().getResourceAsStream(\"/Test.png\"))",
+				"Classpath: /Test.png",
+				getInvocationSource(shell(), "{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	/**
 	 * Image creation using constructor with input stream (over class resource).
 	 */
-	@Disabled
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
+		setFileContentSrc("test", "OtherClass.java", """
+				package test;
+				public class OtherClass {}
+				""");
 		assert_getText_getClipboardSource_forSource(
-				"new Image(null, java.lang.String.class.getResourceAsStream(\"/javax/swing/plaf/basic/icons/JavaCup16.png\"))",
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource(shell(), "{wbp_classTop}", "/javax/swing/plaf/basic/icons/JavaCup16.png"));
+				"new Image(null, OtherClass.class.getResourceAsStream(\"/Test.png\"))",
+				"Classpath: /Test.png",
+				getInvocationSource(shell(), "{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	////////////////////////////////////////////////////////////////////////////
@@ -152,11 +156,12 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	 */
 	@Test
 	public void test_textSource_image_over_classpath2() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		CompositeInfo shell = shell();
 		assert_getText_getClipboardSource_forSource2(
-				getInvocationSource(shell, "getClass()", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource(shell, "{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource(shell, "getClass()", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource(shell, "{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	/**
@@ -164,11 +169,12 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	 */
 	@Test
 	public void test_textSource_image_over_classpath_OtherClass2() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		CompositeInfo shell = shell();
 		assert_getText_getClipboardSource_forSource2(
-				getInvocationSource(shell, "java.lang.String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""),
-				"Classpath: /javax/swing/plaf/basic/icons/JavaCup16.png",
-				getInvocationSource(shell, "{wbp_classTop}", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource(shell, "java.lang.String.class", "\"/Test.png\""),
+				"Classpath: /Test.png",
+				getInvocationSource(shell, "{wbp_classTop}", "\"/Test.png\""));
 	}
 
 	/**
@@ -201,6 +207,7 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 	 */
 	@Test
 	public void test_textSource_order() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		CompositeInfo shell = parseComposite("""
 				// filler filler filler
 				public class Test extends Shell {
@@ -209,7 +216,7 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 				}""");
 		ManagerContainerInfo.getResourceManagerInfo(shell);
 		shell.addMethodInvocation("setImage(org.eclipse.swt.graphics.Image)",
-				getInvocationSource(shell, "java.lang.String.class", "\"/javax/swing/plaf/basic/icons/JavaCup16.png\""));
+				getInvocationSource(shell, "java.lang.String.class", "\"/Test.png\""));
 		shell.refresh();
 		assertEditor("""
 				// filler filler filler
@@ -217,7 +224,7 @@ public class ImagePropertyEditorTestWithManager extends ImagePropertyEditorTest 
 					private LocalResourceManager localResourceManager;
 					public Test() {
 						createResourceManager();
-						setImage(localResourceManager.create(ImageDescriptor.createFromFile(String.class, \"/javax/swing/plaf/basic/icons/JavaCup16.png\")));
+						setImage(localResourceManager.create(ImageDescriptor.createFromFile(String.class, \"/Test.png\")));
 					}
 					private void createResourceManager() {
 						localResourceManager = new LocalResourceManager(JFaceResources.getResources(),this);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ResourceManagerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.wb.tests.designer.swt.model.property;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.utils.ManagerUtils;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
 import org.eclipse.swt.SWT;
@@ -95,13 +96,14 @@ public class ResourceManagerTest extends RcpModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_getImageDescriptor() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		// create image descriptor
 		Object imageDescriptor =
 				ReflectionUtils.invokeMethod(
 						ManagerClass,
 						"getImageDescriptor(java.lang.Class,java.lang.String)",
 						ManagerClass,
-						"/javax/swing/plaf/basic/icons/JavaCup16.png");
+						"/Test.png");
 		// check create
 		assertNotNull(imageDescriptor);
 	}
@@ -119,13 +121,14 @@ public class ResourceManagerTest extends RcpModelTest {
 
 	@Test
 	public void test_getImage() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		// create image descriptor
 		Object imageDescriptor =
 				ReflectionUtils.invokeMethod(
 						ImageDescriptorClass,
 						"createFromFile(java.lang.Class,java.lang.String)",
 						ManagerClass,
-						"/javax/swing/plaf/basic/icons/JavaCup16.png");
+						"/Test.png");
 		// check create
 		assertNotNull(imageDescriptor);
 		//

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/SWTResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/SWTResourceManagerTest.java
@@ -15,18 +15,20 @@ package org.eclipse.wb.tests.designer.swt.model.property;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 import org.eclipse.wb.internal.swt.model.widgets.CompositeInfo;
 import org.eclipse.wb.internal.swt.utils.ManagerUtils;
+import org.eclipse.wb.tests.designer.TestUtils;
 import org.eclipse.wb.tests.designer.rcp.RcpModelTest;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 
@@ -211,16 +213,17 @@ public class SWTResourceManagerTest extends RcpModelTest {
 		}
 	}
 
-	@Disabled
 	@Test
 	public void test_getImage_classpath() throws Exception {
+		IFile imageSrc = setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
+		waitForAutoBuild();
 		// create image over SWTResourceManager
 		Image image = (Image)
 				ReflectionUtils.invokeMethod(
 						SWTManagerClass,
 						"getImage(java.lang.Class,java.lang.String)",
 						SWTManagerClass,
-						"/javax/swing/plaf/basic/icons/JavaCup16.png");
+						"/Test.png");
 		// check create
 		assertNotNull(image);
 		// check state
@@ -229,12 +232,12 @@ public class SWTResourceManagerTest extends RcpModelTest {
 				SWTManagerClass,
 				"getImage(java.lang.Class,java.lang.String)",
 				SWTManagerClass,
-				"/javax/swing/plaf/basic/icons/JavaCup16.png"));
+				"/Test.png"));
 		// load image directly over Image
-		Image directImage = new Image(null,
-				getClass().getResourceAsStream("/javax/swing/plaf/basic/icons/JavaCup16.png"));
 		// check equals images
-		try {
+		Image directImage = null;
+		try (InputStream is = imageSrc.getContents()) {
+			directImage = new Image(null, is);
 			assertEqualsImage(image, directImage);
 		} finally {
 			directImage.dispose();
@@ -287,13 +290,14 @@ public class SWTResourceManagerTest extends RcpModelTest {
 
 	@Test
 	public void test_disposeImages() throws Exception {
+		setFileContentSrc("Test.png", TestUtils.createImagePNG(1, 1));
 		// create image over SWTResourceManager
 		Object image =
 				ReflectionUtils.invokeMethod(
 						SWTManagerClass,
 						"getImage(java.lang.Class,java.lang.String)",
 						SWTManagerClass,
-						"/javax/swing/plaf/basic/icons/JavaCup16.png");
+						"/Test.png");
 		// check create
 		assertNotNull(image);
 		// check state


### PR DESCRIPTION
With recent Java versions, JDK-internal JavaCup16.png is no longer in the classpath, which is why those tests were disabled. This image has to be replaced with a "test" image, similar to what was already done in the past with 331b23247cd2529cbf7ba500e3ccc4cf141d0794.