### PR TITLE
Use plain Draw2D Figure for test cases

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/Figure.java
@@ -17,7 +17,6 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Insets;
 import org.eclipse.draw2d.geometry.Rectangle;
 
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -28,20 +27,6 @@ import java.util.List;
  * @coverage gef.draw2d
  */
 public class Figure extends org.eclipse.draw2d.Figure {
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// Events support
-	//
-	////////////////////////////////////////////////////////////////////////////
-	/**
-	 * Return all registers listeners for given class or <code>null</code>.
-	 */
-	@Override
-	public <T extends Object> Iterator<T> getListeners(Class<T> listenerClass) {
-		return super.getListeners(listenerClass);
-	}
-
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Figure

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureEventTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureEventTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.draw2d;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.tests.gef.EventSender;
 import org.eclipse.wb.tests.gef.TestLogger;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.MouseEvent;
 import org.eclipse.draw2d.MouseListener;
 import org.eclipse.draw2d.MouseMotionListener;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigurePaintingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.draw2d;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.tests.gef.TestLogger;
 
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.XYLayout;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -57,7 +57,7 @@ public class FigurePaintingTest extends Draw2dFigureTestCase {
 	}
 
 	private Figure addFigure(int x, int y, int width, int height) {
-		Figure figure = new Figure();
+		Figure figure = new TestCaseFigure();
 		figure.setBounds(new Rectangle(x, y, width, height));
 		figure.setLayoutManager(new XYLayout());
 		m_root.add(figure);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.draw2d;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.border.Border;
 import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.draw2d.border.MarginBorder;
@@ -20,6 +19,7 @@ import org.eclipse.wb.tests.gef.TestLogger;
 
 import org.eclipse.draw2d.AncestorListener;
 import org.eclipse.draw2d.Cursors;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Label;
@@ -697,7 +697,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_add_remove_MouseListener() throws Exception {
-		Figure testFigure = new Figure();
+		TestCaseFigure testFigure = new TestCaseFigure();
 		//
 		// check init state of listener for new Figure
 		assertFalse(testFigure.getListeners(MouseListener.class).hasNext());
@@ -737,7 +737,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 
 	@Test
 	public void test_add_remove_MouseMoveListener() throws Exception {
-		Figure testFigure = new Figure();
+		TestCaseFigure testFigure = new TestCaseFigure();
 		//
 		// check init state of listener for new Figure
 		assertFalse(testFigure.getListeners(MouseMotionListener.class).hasNext());
@@ -777,7 +777,7 @@ public class FigureTest extends Draw2dFigureTestCase {
 
 	@Test
 	public void test_add_remove_FigureListener() throws Exception {
-		Figure testFigure = new Figure();
+		TestCaseFigure testFigure = new TestCaseFigure();
 		//
 		// check init state of listener for new Figure
 		assertFalse(testFigure.getListeners(FigureListener.class).hasNext());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LayerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/LayerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.draw2d;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.tests.gef.TestLogger;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.draw2d;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
 import org.eclipse.wb.internal.draw2d.RootFigure;
 import org.eclipse.wb.tests.gef.TestLogger;
 
 import org.eclipse.draw2d.DeferredUpdateManager;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.UpdateListener;
 import org.eclipse.draw2d.UpdateManager;
 import org.eclipse.draw2d.geometry.Dimension;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseFigure.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/TestCaseFigure.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Google, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.wb.tests.draw2d;
+
+import org.eclipse.draw2d.Figure;
+
+import java.util.Iterator;
+
+public class TestCaseFigure extends Figure {
+	@Override
+	public <T extends Object> Iterator<T> getListeners(Class<T> listenerClass) {
+		return super.getListeners(listenerClass);
+	}
+
+	@Override
+	protected boolean useLocalCoordinates() {
+		return true;
+	}
+}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EditPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EditPartTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.policies.DesignEditPolicy;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.eclipse.draw2d.EventListenerList;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartListener;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GefCursorTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GefCursorTestCase.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
@@ -26,6 +25,7 @@ import org.eclipse.wb.internal.draw2d.FigureCanvas;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 import org.eclipse.wb.internal.gef.graphical.GraphicalViewer;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalViewerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/GraphicalViewerTest.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.core.tools.Tool;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.gef.core.EditDomain;
 import org.eclipse.wb.internal.gef.graphical.GraphicalViewer;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.gef.EditPart;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestTestCaseEditPart.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestTestCaseEditPart.java
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
+import org.eclipse.wb.tests.draw2d.TestCaseFigure;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
@@ -49,7 +50,7 @@ public class RequestTestCaseEditPart extends DesignEditPart {
 	////////////////////////////////////////////////////////////////////////////
 	@Override
 	protected Figure createFigure() {
-		return new Figure();
+		return new TestCaseFigure();
 	}
 
 	@Override

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/RequestsTest.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.core.requests.CreateRequest;
 import org.eclipse.wb.gef.core.requests.ICreationFactory;
 import org.eclipse.wb.gef.core.requests.PasteRequest;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;


### PR DESCRIPTION
This moves the getListeners(...) method to a dedicated test-figure, as it is only called during test execution.