### PR TITLE
Reduce code duplication in DesignColorProvider

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerColorProvider.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/palette/DesignerColorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Patrick Ziegler and others.
+ * Copyright (c) 2025, 2026 Patrick Ziegler and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.editor.palette;
 
+import org.eclipse.wb.internal.core.utils.ui.DrawUtils;
+
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.gef.ui.palette.PaletteColorProvider;
 import org.eclipse.swt.graphics.Color;
@@ -22,9 +24,9 @@ import org.eclipse.swt.graphics.Color;
  */
 public class DesignerColorProvider extends PaletteColorProvider {
 	public static final Color COLOR_PALETTE_BACKGROUND = ColorConstants.button;
-	public static final Color COLOR_ENTRY_SELECTED = getShiftedColor(COLOR_PALETTE_BACKGROUND, 24);
-	public static final Color COLOR_DRAWER_GRAD_BEGIN = getShiftedColor(COLOR_PALETTE_BACKGROUND, -8);
-	public static final Color COLOR_DRAWER_GRAD_END = getShiftedColor(COLOR_PALETTE_BACKGROUND, 16);
+	public static final Color COLOR_ENTRY_SELECTED = DrawUtils.getShiftedColor(COLOR_PALETTE_BACKGROUND, 24);
+	public static final Color COLOR_DRAWER_GRAD_BEGIN = DrawUtils.getShiftedColor(COLOR_PALETTE_BACKGROUND, -8);
+	public static final Color COLOR_DRAWER_GRAD_END = DrawUtils.getShiftedColor(COLOR_PALETTE_BACKGROUND, 16);
 
 	@Override
 	public Color getListSelectedBackgroundColor() {
@@ -39,16 +41,5 @@ public class DesignerColorProvider extends PaletteColorProvider {
 	@Override
 	public Color getListBackground() {
 		return COLOR_PALETTE_BACKGROUND;
-	}
-
-	/**
-	 * @return new {@link Color} based on given {@link Color} and shifted on given
-	 *         value to make it darker or lighter.
-	 */
-	private static Color getShiftedColor(Color color, int delta) {
-		int r = Math.max(0, Math.min(color.getRed() + delta, 255));
-		int g = Math.max(0, Math.min(color.getGreen() + delta, 255));
-		int b = Math.max(0, Math.min(color.getBlue() + delta, 255));
-		return new Color(color.getDevice(), r, g, b);
 	}
 }


### PR DESCRIPTION
Use the identical `getShiftedColor()` method from DrawUtils instead of the local method.