### PR TITLE
Add a more exhaustive failure message for the "Open Type" animation

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
@@ -29,9 +29,11 @@ import org.eclipse.wb.tests.gef.UiContext;
 
 import org.eclipse.swtbot.swt.finder.SWTBot;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableRunnable;
-import org.junit.jupiter.api.Test;
 
 import javax.swing.JButton;
 import javax.swing.JMenu;
@@ -52,6 +54,13 @@ public class ActionGefTest extends SwingGefTest {
 		System.exit(0);
 	}
 
+	@Override
+	@BeforeEach
+	public void setUp() throws Exception {
+		super.setUp();
+		createExternalAction();
+	}
+
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// JToolBar
@@ -62,7 +71,6 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JToolBar_ActionNewEntryInfo() throws Exception {
-		createExternalAction();
 		ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {
 					public Test() {
@@ -131,7 +139,6 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JToolBar_ActionUseEntryInfo_canvas() throws Exception {
-		createExternalAction();
 		ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {
 					private ExternalAction action = new ExternalAction();
@@ -182,7 +189,6 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JToolBar_ActionUseEntryInfo_tree() throws Exception {
-		createExternalAction();
 		ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {
 					private ExternalAction action = new ExternalAction();
@@ -233,7 +239,6 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JToolBar_ActionExternalEntryInfo() throws Exception {
-		createExternalAction();
 		final ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {
 					public Test() {
@@ -306,7 +311,6 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JButton_setAction() throws Exception {
-		createExternalAction();
 		ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {
 					private ExternalAction action = new ExternalAction();
@@ -350,7 +354,6 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JMenu_dropBetween_JMenuItem() throws Exception {
-		createExternalAction();
 		ContainerInfo frame = openContainer("""
 				public class Test extends JFrame {
 					private ExternalAction action = new ExternalAction();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -41,6 +41,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotLabel;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
@@ -468,10 +469,9 @@ public abstract class DesignerTestCase extends Assertions {
 		SWTBotShell shellBot = bot.shell("Open type");
 		SWTBot shell = shellBot.bot();
 		// set filter
-		{
-			SWTBotText filterText = shell.text();
-			filterText.setText(typeName);
-		}
+		SWTBotText filterText = shell.text();
+		filterText.setText(typeName);
+
 		// wait for types
 		{
 			final SWTBotTable typesTable = shell.table();
@@ -483,7 +483,13 @@ public abstract class DesignerTestCase extends Assertions {
 
 				@Override
 				public String getFailureMessage() {
-					return "\"Open type\" dialog took too long to find types.";
+					SWTBotLabel progressLabel = shell.label(2);
+					return """
+							"Open type" dialog took too long to find types.
+							- Number of Items: %d
+							- Filter Text: "%s"
+							- Progress: "%s"
+							""".formatted(typesTable.rowCount(), filterText.getText(), progressLabel.getText());
 				}
 			});
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.swt.finder.SWTBot;
@@ -78,6 +79,10 @@ public class UiContext {
 						System.err.println(shell);
 					}
 				});
+				System.err.println("Active Jobs:");
+				for (Job job : Job.getJobManager().find(null)) {
+					System.err.println(job.getName() + " - " + job.getState());
+				}
 				e.printStackTrace();
 				checkException[0] = e;
 			} finally {


### PR DESCRIPTION
The message should include the number of filtered items, the filter text and the current progress message.