### PR TITLE
[Draw2D] SemiTransparentFigure should extend Draw2D figure

### DIFF
--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/SemiTransparentFigure.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/internal/draw2d/SemiTransparentFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.draw2d;
 
-import org.eclipse.wb.draw2d.Figure;
-
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Image;
@@ -44,8 +43,8 @@ public class SemiTransparentFigure extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
-		Rectangle clientArea = getClientArea();
+	protected void paintFigure(Graphics graphics) {
+		Rectangle clientArea = getBounds();
 		// prepare image 1x1
 		Image image;
 		{
@@ -58,7 +57,7 @@ public class SemiTransparentFigure extends Figure {
 			image = new Image(null, data);
 		}
 		// stretch image on client area
-		graphics.drawImage(image, 0, 0, 1, 1, 0, 0, clientArea.width, clientArea.height);
+		graphics.drawImage(image, 0, 0, 1, 1, clientArea.x, clientArea.y, clientArea.width, clientArea.height);
 		image.dispose();
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/AbstractPositionFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/AbstractPositionFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,10 @@ import org.eclipse.draw2d.geometry.Rectangle;
  *
  * @author scheglov_ke
  * @coverage core.gef.figure
+ * @deprecated This class will be internalized after the 2028-06 release.
  */
+//TODO ptziegler - unify with GhostPositionFeedback once SolidPositionFeedback has been deleted
+@Deprecated(forRemoval = true, since = "2026-06")
 public abstract class AbstractPositionFeedback {
 	private final Layer m_layer;
 	private final String m_hint;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/GhostPositionFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/GhostPositionFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,10 +13,10 @@
 package org.eclipse.wb.core.gef.figure;
 
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.internal.draw2d.SemiTransparentFigure;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Color;
 
@@ -25,7 +25,10 @@ import org.eclipse.swt.graphics.Color;
  *
  * @author scheglov_ke
  * @coverage core.gef.figure
+ * @deprecated This class will be internalized after the 2028-06 release.
  */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2026-06")
 public final class GhostPositionFeedback extends AbstractPositionFeedback {
 	private static final Color m_fillColor = new Color(null, 0, 255, 0);
 	private static final Color m_activeColor = new Color(null, 255, 255, 0);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/SolidPositionFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/SolidPositionFeedback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.figure;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.Layer;
-import org.eclipse.wb.draw2d.border.LineBorder;
 
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Color;
 
@@ -26,13 +26,18 @@ import org.eclipse.swt.graphics.Color;
  *
  * @author scheglov_ke
  * @coverage core.gef.figure
+ * @deprecated Not used anymore. This class will be removed after the 2028-06
+ *             release.
  */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "2026-06")
 public final class SolidPositionFeedback extends AbstractPositionFeedback {
 	////////////////////////////////////////////////////////////////////////////
 	//
 	// Constructor
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Deprecated(forRemoval = true, since = "2026-06")
 	public SolidPositionFeedback(Layer layer, Rectangle bounds, String hint) {
 		super(layer, bounds, hint);
 	}
@@ -42,6 +47,7 @@ public final class SolidPositionFeedback extends AbstractPositionFeedback {
 	// Figure methods
 	//
 	////////////////////////////////////////////////////////////////////////////
+	@Deprecated(forRemoval = true, since = "2026-06")
 	@Override
 	protected IFigure createFigure() {
 		IFigure figure = new Figure();
@@ -50,6 +56,7 @@ public final class SolidPositionFeedback extends AbstractPositionFeedback {
 		return figure;
 	}
 
+	@Deprecated(forRemoval = true, since = "2026-06")
 	@Override
 	public void update(boolean contains) {
 		if (contains) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridLayoutEditPolicy.java
@@ -22,13 +22,13 @@ import org.eclipse.wb.core.model.IAbstractComponentInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectEventListener;
 import org.eclipse.wb.draw2d.FigureUtils;
-import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.gef.core.IEditPartViewer;
 import org.eclipse.wb.gef.graphical.policies.LayoutEditPolicy;
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.draw2d.SemiTransparentFigure;
 
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/position/AbstractPositionLayoutEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/position/AbstractPositionLayoutEditPolicy.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.layout.position;
 
-import org.eclipse.wb.core.gef.figure.AbstractPositionFeedback;
 import org.eclipse.wb.core.gef.figure.GhostPositionFeedback;
 import org.eclipse.wb.core.gef.figure.TextFeedback;
 import org.eclipse.wb.core.gef.policy.PolicyUtils;
@@ -48,8 +47,10 @@ public abstract class AbstractPositionLayoutEditPolicy extends LayoutEditPolicy 
 	//
 	////////////////////////////////////////////////////////////////////////////
 	private TextFeedback m_hintFeedback;
-	private List<AbstractPositionFeedback> m_feedbacks;
-	private AbstractPositionFeedback m_activeFeedback;
+	@SuppressWarnings("removal")
+	private List<GhostPositionFeedback> m_feedbacks;
+	@SuppressWarnings("removal")
+	private GhostPositionFeedback m_activeFeedback;
 
 	@Override
 	protected final void showLayoutTargetFeedback(Request request) {
@@ -70,7 +71,7 @@ public abstract class AbstractPositionLayoutEditPolicy extends LayoutEditPolicy 
 		// highlight feedback
 		m_activeFeedback = null;
 		Point location = PolicyUtils.getAbsoluteLocation(getHost(), (DropRequest) request);
-		for (AbstractPositionFeedback feedback : m_feedbacks) {
+		for (@SuppressWarnings("removal") GhostPositionFeedback feedback : m_feedbacks) {
 			if (feedback.update(location)) {
 				m_activeFeedback = feedback;
 			}
@@ -93,7 +94,7 @@ public abstract class AbstractPositionLayoutEditPolicy extends LayoutEditPolicy 
 		super.eraseLayoutTargetFeedback(request);
 		if (m_feedbacks != null) {
 			// remove positions
-			for (AbstractPositionFeedback feedback : m_feedbacks) {
+			for (@SuppressWarnings("removal") GhostPositionFeedback feedback : m_feedbacks) {
 				feedback.remove();
 			}
 			m_feedbacks = null;
@@ -122,7 +123,8 @@ public abstract class AbstractPositionLayoutEditPolicy extends LayoutEditPolicy 
 		}
 		// add feedback
 		{
-			AbstractPositionFeedback feedback = new GhostPositionFeedback(layer, bounds, hint);
+			@SuppressWarnings("removal")
+			GhostPositionFeedback feedback = new GhostPositionFeedback(layer, bounds, hint);
 			feedback.setData(data);
 			m_feedbacks.add(feedback);
 		}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/TopResizeFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.selection;
 
-import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.internal.draw2d.SemiTransparentFigure;
 
 import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.TextUtilities;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -61,10 +61,10 @@ public class TopResizeFigure extends SemiTransparentFigure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
-		super.paintClientArea(graphics);
+	protected void paintFigure(Graphics graphics) {
+		super.paintFigure(graphics);
 		if (!StringUtils.isEmpty(m_sizeText)) {
-			Rectangle area = getClientArea();
+			Rectangle area = getBounds();
 			Font oldFont = graphics.getFont();
 			Font newFont = FontDescriptor.createFrom(oldFont) //
 					.setHeight(16) //


### PR DESCRIPTION
This adapts the `SemiTransparentFigure` and `TopResizeFigure` to extend a plain Draw2D `Figure` directly. The references have been adapted to also use the Draw2D `LineBorder` to avoid the issues when translating between absolute and local coordinates.

The `AbstractPositionFeedback` and `GhostPositionFeedback` have been marked as "for removal" and will be internalized after the 2028-06 release. The `SemiTransparentFigure` has also been marked for removal and will be removed alltogether.