### PR TITLE
Only execute test_JToolBar_ActionExternalEntryInfo on Linux

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionGefTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.designer.swing.model.bean;
 
+import org.eclipse.wb.internal.core.EnvironmentUtils;
 import org.eclipse.wb.internal.swing.model.bean.ActionContainerInfo;
 import org.eclipse.wb.internal.swing.model.bean.ActionInfo;
 import org.eclipse.wb.internal.swing.model.component.ComponentInfo;
@@ -28,6 +29,8 @@ import org.eclipse.wb.tests.gef.UiContext;
 
 import org.eclipse.gef.Tool;
 import org.eclipse.swtbot.swt.finder.SWTBot;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableRunnable;
@@ -233,6 +236,7 @@ public class ActionGefTest extends SwingGefTest {
 	 */
 	@Test
 	public void test_JToolBar_ActionExternalEntryInfo() throws Exception {
+		assumeFalse(EnvironmentUtils.IS_WINDOWS);
 		createExternalAction();
 		final ContainerInfo panel = openContainer("""
 				public class Test extends JPanel {


### PR DESCRIPTION
This test case was enabled with 53708fff3d159bb7d38997dd2275ac5671866cee but almost always fails on Windows, for unknow reason. The test itself opens the "external action" tool from the palette, which in return opens the "Open Type" dialog.

In this dialog, we search for the `ExternalAction` class that was added at the start of the test. For whatever reason, this type is not found. Reason is likely some weird I/O interaction between the Windows file system and JDT, where JDT hasn't realized that this new type was added.