### PR TITLE
[Draw2D] Use Draw2D BorderLayout for LineSelection selection policy

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/LineSelectionEditPolicy.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/selection/LineSelectionEditPolicy.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.policy.selection;
 
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
-import org.eclipse.wb.draw2d.border.LineBorder;
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
 
 import org.eclipse.draw2d.AncestorListener;
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.LineBorder;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.Handle;


### PR DESCRIPTION
This adapts the `LineSelectionEditPolicy` to use the Draw2D `LineBorder` directly to show the feedback when selection a JFace viewer.