### PR TITLE
Don't parse Swing components in SWT UI thread #1484

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
@@ -464,7 +464,7 @@ public final class DesignPage implements IDesignPage {
 			}
 		};
 		try {
-			new ProgressMonitorDialog(DesignerPlugin.getShell()).run(false, false, runnable);
+			new ProgressMonitorDialog(DesignerPlugin.getShell()).run(true, false, runnable);
 		} catch (InvocationTargetException e) {
 			ReflectionUtils.propagate(e.getCause());
 		} catch (Throwable e) {
@@ -579,12 +579,12 @@ public final class DesignPage implements IDesignPage {
 		{
 			long start = System.currentTimeMillis();
 			monitor.subTask("Refreshing...");
-			m_rootObject.refresh();
+			ExecutionUtils.runRethrowUI(m_rootObject::refresh);
 			monitor.worked(1);
 			Debug.println("refresh: " + (System.currentTimeMillis() - start));
 		}
 		// refresh design
-		m_designComposite.refresh(m_rootObject, monitor);
+		ExecutionUtils.runRethrowUI(() -> m_designComposite.refresh(m_rootObject, monitor));
 		// configure helpers
 		m_undoManager.setRoot(m_rootObject);
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/top/JPanelTopBoundsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -95,8 +95,7 @@ public class JPanelTopBoundsTest extends SwingGefTest {
 	 * The size of the JPanel should be able to exceed the display resolution.
 	 */
 	@Test
-	public void test_resize_veryBig() throws Exception {
-		// expand horizontally
+	public void test_resize_veryBig_expandHorizontallly() throws Exception {
 		Dimension oldSize = new Dimension(500, 400);
 		Dimension newSize = new Dimension(5000, 400);
 		check_resize_JPanel(
@@ -104,11 +103,17 @@ public class JPanelTopBoundsTest extends SwingGefTest {
 				oldSize,
 				newSize,
 				"setSize(new Dimension(5000, 400));");
-		// expand vertically
-		oldSize = new Dimension(5000, 400);
-		newSize = new Dimension(500, 4000);
+	}
+
+	/**
+	 * The size of the JPanel should be able to exceed the display resolution.
+	 */
+	@Test
+	public void test_resize_veryBig_expandVertically() throws Exception {
+		Dimension oldSize = new Dimension(500, 400);
+		Dimension newSize = new Dimension(500, 4000);
 		check_resize_JPanel(
-				"setSize(new Dimension(5000, 400));",
+				"setSize(new Dimension(500, 400));",
 				oldSize,
 				newSize,
 				"setSize(new Dimension(500, 4000));");


### PR DESCRIPTION
With this change, each parse factory may now define a realm (i.e. a thread) with which the compilation unit is created and with which the `JavaInfo` objects are created. For Swing, this is the AWT event dispatcher thread and for SWT the Display thread.

Currently parsing is always done in the SWT UI thread. However, this may cause issues if Swing requires exclusive access to the OS-specififc UI toolkit while SWT holds a (partial) lock.

In addition to using this realm, the refresh action is now executed in a separate thread. All editor access therefore also needs to be explicitly synchronized with the SWT UI thread.

See:
https://github.com/eclipse-windowbuilder/windowbuilder/issues/753 https://github.com/eclipse-windowbuilder/windowbuilder/issues/1484

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/928