### PR TITLE
Fix potential NPE when refreshing MenuObjectEditPart

### DIFF
--- a/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
+++ b/org.eclipse.wb.core/src-gef/org/eclipse/wb/gef/core/EditPart.java
@@ -152,7 +152,11 @@ public abstract class EditPart extends org.eclipse.gef.editparts.AbstractEditPar
 	 */
 	@Override
 	public IEditPartViewer getViewer() {
-		return getParent().getViewer();
+		EditPart parent = getParent();
+		if (parent == null) {
+			return null;
+		}
+		return parent.getViewer();
 	}
 
 	/**

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuObjectEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/part/menu/MenuObjectEditPart.java
@@ -22,6 +22,7 @@ import org.eclipse.wb.internal.core.model.menu.MenuObjectInfoUtils;
 import org.eclipse.wb.internal.gef.core.IActiveToolListener;
 
 import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.RequestConstants;
 import org.eclipse.gef.Tool;
@@ -203,13 +204,14 @@ public abstract class MenuObjectEditPart extends DesignEditPart implements IMenu
 			AsyncExecutor.schedule(new Runnable() {
 				@Override
 				public void run() {
+					EditPartViewer viewer = getViewer();
+					// Edit part is already disposed
+					if (viewer == null) {
+						return;
+					}
 					try {
 						MenuObjectInfoUtils.m_selectingObject = m_object;
-						for (EditPart editPart : List.copyOf(getViewer().getEditPartRegistry().values())) {
-							if (editPart instanceof MenuObjectEditPart) {
-								editPart.refresh();
-							}
-						}
+						refreshRecursively(viewer.getRootEditPart());
 					} finally {
 						MenuObjectInfoUtils.m_selectingObject = null;
 					}
@@ -217,6 +219,16 @@ public abstract class MenuObjectEditPart extends DesignEditPart implements IMenu
 			});
 		}
 		return target;
+	}
+
+	private void refreshRecursively(EditPart editPart) {
+		if (editPart instanceof MenuObjectEditPart) {
+			// Might remove children, so we have to traverse top-down
+			editPart.refresh();
+		}
+		for (EditPart childEditPart : editPart.getChildren()) {
+			refreshRecursively(childEditPart);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
By virtue of being executed asynchronously, the refresh operation within the `MenuObjectEditPart` might throw a `NullPointerException` when executed after the viewer has been disposed. Additionally, it may also throw an exception when the edit parts that are being refresh no longer exists, which might happen if they are former children of a different `MenuObjectEditPart` which was refreshed earlier.