### PR TITLE
Disable `test_zeroSize` test on Linux

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/ComponentTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/ComponentTest.java
@@ -31,6 +31,8 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.RGB;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.awt.Component;
 import java.awt.Container;
@@ -84,6 +86,7 @@ public class ComponentTest extends SwingModelTest {
 	 * We can not create {@link java.awt.Image} with zero size, so we should check this.
 	 */
 	@Test
+	@DisabledOnOs(OS.LINUX)
 	public void test_zeroSize() throws Exception {
 		ContainerInfo panel = parseContainer("""
 				public class Test extends JPanel {


### PR DESCRIPTION
This test was reactivated with 19b2f7b65a54b8d02d852d276bbfa37d5d215e0d but is almost always failing on the Linux build nodes, but not locally. With this change, it is now only executed on Windows.