### PR TITLE
Use `ColorConstants.black` in ElPropertyUiConfiguration

### DIFF
--- a/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.databinding/META-INF/MANIFEST.MF
@@ -2,10 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.databinding;singleton:=true
-Bundle-Version: 1.10.0.qualifier
+Bundle-Version: 1.10.100.qualifier
 Bundle-Activator: org.eclipse.wb.internal.swing.databinding.Activator
 Bundle-Vendor: %providerName
-Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
+Require-Bundle: org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.300,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",

--- a/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ElPropertyUiConfiguration.java
+++ b/org.eclipse.wb.swing.databinding/src/org/eclipse/wb/internal/swing/databinding/ui/contentproviders/el/ElPropertyUiConfiguration.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.databinding.ui.contentproviders.el;
 
-import org.eclipse.swt.SWT;
+import org.eclipse.draw2d.ColorConstants;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.ui.PlatformUI;
 
 /**
  * Configuration for {@link ElPropertyUiContentProvider}.
@@ -27,7 +26,7 @@ public class ElPropertyUiConfiguration {
 	private int m_rows = 4;
 	private Color m_stringsColor = new Color(42, 0, 255);
 	private Color m_keywordsColor = new Color(127, 0, 85);
-	private Color m_numbersColor = PlatformUI.getWorkbench().getDisplay().getSystemColor(SWT.COLOR_BLACK);
+	private Color m_numbersColor = ColorConstants.black;
 	private Color m_operatorsColor = new Color(0, 57, 29);
 	private Color m_propertiesColor = new Color(130, 0, 0);
 


### PR DESCRIPTION
The class might be loaded outside the SWT UI thread, in which case `PlatformUI.getWorkbench()` returns `null` and thus leading to a `NoClassDefFoundError`.