### PR TITLE
Handle editor activation event asynchronously

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/DesignPage.java
@@ -96,19 +96,12 @@ public final class DesignPage implements IDesignPage {
 		@Override
 		public void partActivated(IWorkbenchPart part) {
 			if (part == m_designerEditor) {
-				ExecutionUtils.runLogLater(new RunnableEx() {
-					@Override
-					public void run() throws Exception {
-						if (!isDisposed()) {
-							GlobalStateJava.activate(m_rootObject);
-							if (m_active) {
-								checkDependenciesOnDesignPageActivation();
-								m_undoManager.deactivate();
-								m_undoManager.activate();
-							}
-						}
-					}
-				});
+				GlobalStateJava.activate(m_rootObject);
+				if (m_active) {
+					checkDependenciesOnDesignPageActivation();
+					m_undoManager.deactivate();
+					m_undoManager.activate();
+				}
 			}
 		}
 	};


### PR DESCRIPTION
We don't know when this event is executed. In the worst case, it might happen in the middle of a refresh operation, where the model is in an inconsistent state.

Contributes to
https://github.com/eclipse-windowbuilder/windowbuilder/pull/1485