### PR TITLE
Fix several try-catch-fail anti-patterns in JUnit tests

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/BundleResourceProviderTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/BundleResourceProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -43,11 +43,7 @@ public class BundleResourceProviderTest extends DesignerTestCase {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_noSuchBundle() throws Exception {
-		try {
-			BundleResourceProvider.get("no.such.bundle");
-			fail();
-		} catch (AssertionFailedException e) {
-		}
+		assertThrows(AssertionFailedException.class, () -> BundleResourceProvider.get("no.such.bundle"));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/EngineTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/EngineTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -78,13 +78,9 @@ public class EngineTest extends AbstractEngineTest {
 						return value;
 					}
 				}""");
-		try {
-			evaluateSingleMethod(typeDeclaration, "foo(int)");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_NO_METHOD_INVOCATION, e.getCode());
-		}
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "foo(int)"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_NO_METHOD_INVOCATION, e.getCode());
 	}
 
 	/**
@@ -128,11 +124,7 @@ public class EngineTest extends AbstractEngineTest {
 			};
 		}
 		// evaluate, we don't return value, so evaluation failed
-		try {
-			AstEvaluationEngine.evaluate(context, expression);
-			fail();
-		} catch (Throwable e) {
-		}
+		assertThrows(Throwable.class, () -> AstEvaluationEngine.evaluate(context, expression));
 		assertTrue(evaluationFailed.get());
 	}
 
@@ -222,13 +214,9 @@ public class EngineTest extends AbstractEngineTest {
 								"  }",
 								"}"));
 		waitForAutoBuild();
-		try {
-			evaluateSingleMethod(typeDeclaration, "getValue()");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_NO_SIMPLE_NAME_FOUND, e.getCode());
-		}
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "getValue()"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_NO_SIMPLE_NAME_FOUND, e.getCode());
 	}
 
 	@Test
@@ -329,13 +317,9 @@ public class EngineTest extends AbstractEngineTest {
 						return value;
 					}
 				}""");
-		try {
-			evaluateSingleMethod(typeDeclaration, "foo(int)");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_NO_METHOD_INVOCATION, e.getCode());
-		}
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "foo(int)"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_NO_METHOD_INVOCATION, e.getCode());
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/ExecutionFlowUtilsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/ExecutionFlowUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -163,13 +163,9 @@ public class ExecutionFlowUtilsTest extends AbstractEngineTest {
 					public Test(double b) {
 					}
 				}""");
-		try {
-			ExecutionFlowUtils.getExecutionFlowConstructor(typeDeclaration);
-			fail();
-		} catch (MultipleConstructorsError e) {
-			assertSame(null, e.getEditor());
-			assertSame(null, e.getTypeDeclaration());
-		}
+		MultipleConstructorsError e = assertThrows(MultipleConstructorsError.class, () -> ExecutionFlowUtils.getExecutionFlowConstructor(typeDeclaration));
+		assertSame(null, e.getEditor());
+		assertSame(null, e.getTypeDeclaration());
 	}
 	/**
 	 * {@link ExecutionFlowProvider} that selects constructor with single <code>int</code> parameter

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/MethodInvocationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/eval/MethodInvocationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -113,13 +113,9 @@ public class MethodInvocationTest extends AbstractEngineTest {
 					}
 				}""");
 		waitForAutoBuild();
-		try {
-			evaluateSingleMethod(typeDeclaration, "root()");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_LOCAL_METHOD_INVOCATION, e.getCode());
-		}
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "root()"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_LOCAL_METHOD_INVOCATION, e.getCode());
 	}
 
 	/**
@@ -158,18 +154,14 @@ public class MethodInvocationTest extends AbstractEngineTest {
 				}""");
 		waitForAutoBuild();
 		//
-		try {
-			evaluateSingleMethod(typeDeclaration, "root()");
-			fail();
-		} catch (Throwable e) {
-			{
-				Throwable rootCause = DesignerExceptionUtils.getRootCause(e);
-				Assertions.assertThat(rootCause).isExactlyInstanceOf(ArithmeticException.class);
-			}
-			{
-				DesignerException de = DesignerExceptionUtils.getDesignerException(e);
-				assertEquals(ICoreExceptionConstants.EVAL_LOCAL_METHOD_INVOCATION, de.getCode());
-			}
+		Throwable e = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "root()"));
+		{
+			Throwable rootCause = DesignerExceptionUtils.getRootCause(e);
+			Assertions.assertThat(rootCause).isExactlyInstanceOf(ArithmeticException.class);
+		}
+		{
+			DesignerException de = DesignerExceptionUtils.getDesignerException(e);
+			assertEquals(ICoreExceptionConstants.EVAL_LOCAL_METHOD_INVOCATION, de.getCode());
 		}
 	}
 
@@ -258,14 +250,10 @@ public class MethodInvocationTest extends AbstractEngineTest {
 
 	@Test
 	public void test_methodInvocation_invalidArguments() throws Exception {
-		try {
-			m_ignoreModelCompileProblems = true;
-			evaluateExpression("Runtime.getRuntime().totalMemory(123)", "long");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_METHOD, e.getCode());
-		}
+		m_ignoreModelCompileProblems = true;
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateExpression("Runtime.getRuntime().totalMemory(123)", "long"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_METHOD, e.getCode());
 	}
 
 	@Test
@@ -277,13 +265,9 @@ public class MethodInvocationTest extends AbstractEngineTest {
 						return obj.hashCode();
 					}
 				}""");
-		try {
-			evaluateSingleMethod(typeDeclaration, "root()");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_NULL_INVOCATION_EXPRESSION, e.getCode());
-		}
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "root()"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_NULL_INVOCATION_EXPRESSION, e.getCode());
 	}
 
 	@Test
@@ -558,9 +542,7 @@ public class MethodInvocationTest extends AbstractEngineTest {
 					"<interceptor class='" + interceptorClass.getName() + "'/>");
 			testBundle.install();
 			try {
-				evaluateExpression("new MyObject()", "Object");
-				fail();
-			} catch (Throwable e) {
+				Throwable e = assertThrows(Throwable.class, () -> evaluateExpression("new MyObject()", "Object"));
 				e = DesignerExceptionUtils.getRootCause(e);
 				assertEquals("rewrite", e.getMessage());
 			} finally {
@@ -588,14 +570,10 @@ public class MethodInvocationTest extends AbstractEngineTest {
 
 	@Test
 	public void test_creation_invalidArguments() throws Exception {
-		try {
-			m_ignoreModelCompileProblems = true;
-			evaluateExpression("new java.util.ArrayList(-3)", "java.lang.Object");
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_CONSTRUCTOR, e.getCode());
-		}
+		m_ignoreModelCompileProblems = true;
+		Throwable e_ = assertThrows(Throwable.class, () -> evaluateExpression("new java.util.ArrayList(-3)", "java.lang.Object"));
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_CONSTRUCTOR, e.getCode());
 	}
 
 	@Test
@@ -859,12 +837,8 @@ public class MethodInvocationTest extends AbstractEngineTest {
 						};
 					}
 				}""");
-		try {
-			evaluateSingleMethod(typeDeclaration, "foo()");
-			fail();
-		} catch (Throwable e) {
-			assertTrue(AnonymousEvaluationError.is(e));
-		}
+		Throwable e = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "foo()"));
+		assertTrue(AnonymousEvaluationError.is(e));
 	}
 
 	/**
@@ -1063,13 +1037,9 @@ public class MethodInvocationTest extends AbstractEngineTest {
 							}
 						}""");
 				// evaluate, but default constructor (used in interceptor) throws exception
-				try {
-					evaluateSingleMethod(typeDeclaration, "foo()");
-					fail();
-				} catch (Throwable e_) {
-					Throwable e = DesignerExceptionUtils.getRootCause(e_);
-					assertInstanceOf(IllegalStateException.class, e);
-				}
+				Throwable e_ = assertThrows(Throwable.class, () -> evaluateSingleMethod(typeDeclaration, "foo()"));
+				Throwable e = DesignerExceptionUtils.getRootCause(e_);
+				assertInstanceOf(IllegalStateException.class, e);
 			} finally {
 				testBundle.uninstall();
 			}
@@ -1196,14 +1166,10 @@ public class MethodInvocationTest extends AbstractEngineTest {
 						"}"));
 		waitForAutoBuild();
 		// validate
-		try {
-			m_ignoreModelCompileProblems = true;
-			test_SuperMethodInvocation2();
-			fail();
-		} catch (Throwable e_) {
-			DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
-			assertEquals(ICoreExceptionConstants.EVAL_SUPER_METHOD, e.getCode());
-		}
+		m_ignoreModelCompileProblems = true;
+		Throwable e_ = assertThrows(Throwable.class, () -> test_SuperMethodInvocation2());
+		DesignerException e = DesignerExceptionUtils.getDesignerException(e_);
+		assertEquals(ICoreExceptionConstants.EVAL_SUPER_METHOD, e.getCode());
 	}
 
 	private Object test_SuperMethodInvocation2() throws Exception {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -568,11 +568,7 @@ public class ObjectInfoTest extends DesignerTestCase {
 		parent.addBroadcastListener(listener);
 		// case 1: only root can be refreshed
 		{
-			try {
-				child.refresh();
-				fail();
-			} catch (IllegalArgumentException e) {
-			}
+			assertThrows(IllegalArgumentException.class, child::refresh);
 			//
 			inOrder.verifyNoMoreInteractions();
 		}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectReferenceInfoTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/ObjectReferenceInfoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,11 +29,7 @@ public class ObjectReferenceInfoTest extends DesignerTestCase {
 	 */
 	@Test
 	public void test_notNull() throws Exception {
-		try {
-			new TestObjectInfo(null);
-			fail();
-		} catch (Throwable e) {
-		}
+		assertThrows(NullPointerException.class, () -> new ObjectReferenceInfo(null));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/EmptyAssociationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/EmptyAssociationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,31 +58,15 @@ public class EmptyAssociationTest extends SwingModelTest {
 		assertSame(button, association.getJavaInfo());
 		assertTrue(association.canDelete());
 		// no getSource()
-		try {
-			association.getSource();
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, association::getSource);
 		// no getStatement()
 		assertNull(association.getStatement());
 		// can not be moved
-		try {
-			association.move(null);
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, () -> association.move(null));
 		// can not be reparented
-		try {
-			association.setParent(null);
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, () -> association.setParent(null));
 		// can not be morphed
-		try {
-			association.getCopy();
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, association::getCopy);
 		// can not be removed
 		{
 			association.remove();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/ImplicitObjectAssociationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/ImplicitObjectAssociationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -48,25 +48,13 @@ public class ImplicitObjectAssociationTest extends SwingModelTest {
 		assertSame(contentPane, association.getJavaInfo());
 		assertTrue(association.canDelete());
 		// no getSource()
-		try {
-			association.getSource();
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, association::getSource);
 		// no getStatement()
 		assertNull(association.getStatement());
 		// can not be moved
-		try {
-			association.move(null);
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, () -> association.move(null));
 		// can not be reparented
-		try {
-			association.setParent(null);
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, () -> association.setParent(null));
 		// delete
 		assertTrue(contentPane.canDelete());
 		contentPane.delete();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/InvocationChildAssociationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/InvocationChildAssociationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -56,11 +56,7 @@ public class InvocationChildAssociationTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_invalid_noParentAccess() throws Exception {
-		try {
-			new InvocationChildAssociation("invalidSource");
-			fail();
-		} catch (AssertionFailedException e) {
-		}
+		assertThrows(AssertionFailedException.class, () -> new InvocationChildAssociation("invalidSource"));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/InvocationSecondaryAssociationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/association/InvocationSecondaryAssociationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -103,17 +103,9 @@ public class InvocationSecondaryAssociationTest extends SwingModelTest {
 					"addGB(getContentPane(), new JButton(\"north\"), BorderLayout.NORTH);",
 					m_lastEditor.getSource(association.getStatement()));
 			// can not be moved
-			try {
-				association.move(null);
-				fail();
-			} catch (NotImplementedException e) {
-			}
+			assertThrows(NotImplementedException.class, () -> association.move(null));
 			// can not be reparented
-			try {
-				association.setParent(null);
-				fail();
-			} catch (NotImplementedException e) {
-			}
+			assertThrows(NotImplementedException.class, () -> association.setParent(null));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ConstructorCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ConstructorCreationSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -989,13 +989,11 @@ public class ConstructorCreationSupportTest extends SwingModelTest {
 						"}");
 		FlowLayoutInfo flowLayout = (FlowLayoutInfo) panel.getLayout();
 		// try to add
-		try {
+		DesignerException e = assertThrows(DesignerException.class, () -> {
 			ComponentInfo newButton = createJavaInfo("test.MyButton");
 			flowLayout.add(newButton, null);
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(ICoreExceptionConstants.GEN_NO_CONSTRUCTOR_BINDING, e.getCode());
-		}
+		});
+		assertEquals(ICoreExceptionConstants.GEN_NO_CONSTRUCTOR_BINDING, e.getCode());
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/FactoryTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/FactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,8 +41,8 @@ public class FactoryTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_parseFactory() throws Exception {
-		try {
-			m_waitForAutoBuild = true;
+		m_waitForAutoBuild = true;
+		DesignerException e = assertThrows(DesignerException.class, () -> {
 			parseContainer(
 					"public final class Test {",
 					"  /**",
@@ -52,10 +52,8 @@ public class FactoryTest extends SwingModelTest {
 					"    return new JButton();",
 					"  }",
 					"}");
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(ICoreExceptionConstants.PARSER_FACTORY_NOT_SUPPORTED, e.getCode());
-			assertTrue(DesignerExceptionUtils.isWarning(e));
-		}
+		});
+		assertEquals(ICoreExceptionConstants.PARSER_FACTORY_NOT_SUPPORTED, e.getCode());
+		assertTrue(DesignerExceptionUtils.isWarning(e));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ICreationSupportPermissionsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ICreationSupportPermissionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -38,11 +38,7 @@ public class ICreationSupportPermissionsTest extends SwingModelTest {
 		JavaInfo javaInfo = null;
 		ICreationSupportPermissions permissions = ICreationSupportPermissions.FALSE;
 		assertFalse(permissions.canDelete(javaInfo));
-		try {
-			permissions.delete(javaInfo);
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, () -> permissions.delete(javaInfo));
 		assertFalse(permissions.canReorder(javaInfo));
 		assertFalse(permissions.canReparent(javaInfo));
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ThisCreationSupportTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/creation/ThisCreationSupportTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -481,17 +481,13 @@ public class ThisCreationSupportTest extends SwingModelTest {
 						"}"));
 		waitForAutoBuild();
 		// parse
-		try {
-			parseContainer(
-					"// filler filler filler",
-					"public class Test extends MyPanel {",
-					"  public Test() {",
-					"  }",
-					"}");
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(ICoreExceptionConstants.EVAL_NON_PUBLIC_CONSTRUCTOR, e.getCode());
-		}
+		DesignerException e = assertThrows(DesignerException.class, () -> parseContainer(
+				"// filler filler filler",
+				"public class Test extends MyPanel {",
+				"  public Test() {",
+				"  }",
+				"}"));
+		assertEquals(ICoreExceptionConstants.EVAL_NON_PUBLIC_CONSTRUCTOR, e.getCode());
 	}
 
 	/**
@@ -511,19 +507,15 @@ public class ThisCreationSupportTest extends SwingModelTest {
 						"}"));
 		waitForAutoBuild();
 		// parse
-		try {
-			m_ignoreCompilationProblems = true;
-			parseContainer(
-					"public class Test extends MyPanel {",
-					"  public Test() {",
-					"    super(0);",
-					"  }",
-					"}");
-			fail();
-		} catch (Throwable e) {
-			DesignerException de = DesignerExceptionUtils.getDesignerException(e);
-			assertEquals(ICoreExceptionConstants.EVAL_BYTEBUDDY, de.getCode());
-		}
+		m_ignoreCompilationProblems = true;
+		Throwable e = assertThrows(Throwable.class, () -> parseContainer(
+				"public class Test extends MyPanel {",
+				"  public Test() {",
+				"    super(0);",
+				"  }",
+				"}"));
+		DesignerException de = DesignerExceptionUtils.getDesignerException(e);
+		assertEquals(ICoreExceptionConstants.EVAL_BYTEBUDDY, de.getCode());
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/CodeGenerationTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/databinding/rcp/model/CodeGenerationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -892,12 +892,7 @@ public class CodeGenerationTest extends AbstractBindingTest {
 		//
 		assertEquals("m_context.getValidationStatusProviders()", observable.getVariableIdentifier());
 		//
-		try {
-			observable.setVariableIdentifier("variable");
-			fail();
-		} catch (Throwable e) {
-			assertInstanceOf(UnsupportedOperationException.class, e);
-		}
+		assertThrows(UnsupportedOperationException.class, () -> observable.setVariableIdentifier("variable"));
 		//
 		List<String> lines = new ArrayList<>();
 		CodeGenerationSupport generationSupport = new CodeGenerationSupport(false, observable);
@@ -949,12 +944,7 @@ public class CodeGenerationTest extends AbstractBindingTest {
 		//
 		assertEquals("m_value", observable.getVariableIdentifier());
 		//
-		try {
-			observable.setVariableIdentifier("variable");
-			fail();
-		} catch (Throwable e) {
-			assertInstanceOf(UnsupportedOperationException.class, e);
-		}
+		assertThrows(UnsupportedOperationException.class, () -> observable.setVariableIdentifier("variable"));
 		//
 		List<String> lines = new ArrayList<>();
 		CodeGenerationSupport generationSupport = new CodeGenerationSupport(false, observable);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/FormToolkitAccessTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/forms/FormToolkitAccessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -64,12 +64,8 @@ public class FormToolkitAccessTest extends AbstractFormsTest {
 				public class Test {
 				}""");
 		assertSame(null, FormToolkitAccess.get(typeDeclaration));
-		try {
-			FormToolkitAccess.getOrFail(typeDeclaration);
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(IExceptionConstants.NO_FORM_TOOLKIT, e.getCode());
-		}
+		DesignerException e = assertThrows(DesignerException.class, () -> FormToolkitAccess.getOrFail(typeDeclaration));
+		assertEquals(IExceptionConstants.NO_FORM_TOOLKIT, e.getCode());
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/WizardPageTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/WizardPageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -158,22 +158,18 @@ public class WizardPageTest extends RcpModelTest {
 	 */
 	@Test
 	public void test_noControl() throws Exception {
-		try {
-			parseJavaInfo(
-					"import org.eclipse.jface.wizard.*;",
-					"public class Test extends WizardPage {",
-					"  public Test() {",
-					"    super('pageName');",
-					"  }",
-					"  public void createControl(Composite parent) {",
-					"  }",
-					"}");
-			fail();
-		} catch (Throwable e) {
-			DesignerException de = DesignerExceptionUtils.getDesignerException(e);
-			assertEquals(IExceptionConstants.NO_CONTROL_IN_WIZARD_PAGE, de.getCode());
-			assertTrue(DesignerExceptionUtils.isWarning(e));
-		}
+		Throwable e = assertThrows(Throwable.class, () -> parseJavaInfo(
+				"import org.eclipse.jface.wizard.*;",
+				"public class Test extends WizardPage {",
+				"  public Test() {",
+				"    super('pageName');",
+				"  }",
+				"  public void createControl(Composite parent) {",
+				"  }",
+				"}"));
+		DesignerException de = DesignerExceptionUtils.getDesignerException(e);
+		assertEquals(IExceptionConstants.NO_CONTROL_IN_WIZARD_PAGE, de.getCode());
+		assertTrue(DesignerExceptionUtils.isWarning(e));
 	}
 
 	@Test
@@ -181,7 +177,7 @@ public class WizardPageTest extends RcpModelTest {
 		String key = "__wbp_WizardPage_simulateException";
 		try {
 			System.setProperty(key, "true");
-			parseJavaInfo(
+			Throwable e = assertThrows(Throwable.class, () -> parseJavaInfo(
 					"import org.eclipse.jface.wizard.*;",
 					"public class Test extends WizardPage {",
 					"  public Test() {",
@@ -191,9 +187,7 @@ public class WizardPageTest extends RcpModelTest {
 					"    Composite container = new Composite(parent, SWT.NULL);",
 					"    setControl(container);",
 					"  }",
-					"}");
-			fail();
-		} catch (Throwable e) {
+					"}"));
 			Throwable rootCause = DesignerExceptionUtils.getRootCause(e);
 			assertEquals("Simulated exception", rootCause.getMessage());
 		} finally {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/WizardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/jface/WizardTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -43,22 +43,18 @@ public class WizardTest extends RcpModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_parsingException() throws Exception {
-		try {
-			parseJavaInfo(
-					"import org.eclipse.jface.wizard.*;",
-					"public class Test extends Wizard {",
-					"  public Test() {",
-					"  }",
-					"  public void addPages() {",
-					"  }",
-					"  public boolean performFinish() {",
-					"    return true;",
-					"  }",
-					"}");
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(IExceptionConstants.NO_DESIGN_WIZARD, e.getCode());
-			assertTrue(DesignerExceptionUtils.isWarning(e));
-		}
+		DesignerException e = assertThrows(DesignerException.class, () -> parseJavaInfo(
+				"import org.eclipse.jface.wizard.*;",
+				"public class Test extends Wizard {",
+				"  public Test() {",
+				"  }",
+				"  public void addPages() {",
+				"  }",
+				"  public boolean performFinish() {",
+				"    return true;",
+				"  }",
+				"}"));
+		assertEquals(IExceptionConstants.NO_DESIGN_WIZARD, e.getCode());
+		assertTrue(DesignerExceptionUtils.isWarning(e));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ActionBarAdvisorTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ActionBarAdvisorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -96,18 +96,10 @@ public class ActionBarAdvisorTest extends RcpModelTest {
 		{
 			IActionBarConfigurer o_IActionBarConfigurer =
 					(IActionBarConfigurer) ReflectionUtils.invokeMethod2(advisor.getObject(), "getActionBarConfigurer");
-			try {
-				o_IActionBarConfigurer.toString();
-				fail();
-			} catch (NotImplementedException e) {
-			}
+			assertThrows(NotImplementedException.class, o_IActionBarConfigurer::toString);
 			// IWorkbenchWindowConfigurer
 			IWorkbenchWindowConfigurer o_IWorkbenchWindowConfigurer = o_IActionBarConfigurer.getWindowConfigurer();
-			try {
-				o_IActionBarConfigurer.toString();
-				fail();
-			} catch (NotImplementedException e) {
-			}
+			assertThrows(NotImplementedException.class, o_IActionBarConfigurer::toString);
 			// IWorkbenchWindow
 			Object o_IWorkbenchWindow = o_IWorkbenchWindowConfigurer.getWindow();
 			assertSame(DesignerPlugin.getActiveWorkbenchWindow(), o_IWorkbenchWindow);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/EditorPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/EditorPartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -147,11 +147,7 @@ public class EditorPartTest extends RcpModelTest {
 		part.refresh();
 		//
 		IEditorSite editorSite = (IEditorSite) ReflectionUtils.invokeMethod(part.getObject(), "getEditorSite()");
-		try {
-			editorSite.getShell();
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, editorSite::getShell);
 		assertEquals("IEditorSite_stub", editorSite.toString());
 		assertEquals(0, editorSite.hashCode());
 		assertEquals("some.editor.Identifier", editorSite.getId());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/MultiPageEditorPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/MultiPageEditorPartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -41,27 +41,23 @@ public class MultiPageEditorPartTest extends RcpModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_parsingException() throws Exception {
-		try {
-			parseJavaInfo(
-					"import org.eclipse.core.runtime.IProgressMonitor;",
-					"import org.eclipse.ui.part.MultiPageEditorPart;",
-					"public abstract class Test extends MultiPageEditorPart {",
-					"  public Test() {",
-					"  }",
-					"  protected void createPages() {",
-					"  }",
-					"  public boolean isSaveAsAllowed() {",
-					"    return false;",
-					"  }",
-					"  public void doSave(IProgressMonitor monitor) {",
-					"  }",
-					"  public void doSaveAs() {	",
-					"  }",
-					"}");
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(IExceptionConstants.NO_DESIGN_MP_EDITOR, e.getCode());
-			assertTrue(DesignerExceptionUtils.isWarning(e));
-		}
+		DesignerException e = assertThrows(DesignerException.class, () -> parseJavaInfo(
+				"import org.eclipse.core.runtime.IProgressMonitor;",
+				"import org.eclipse.ui.part.MultiPageEditorPart;",
+				"public abstract class Test extends MultiPageEditorPart {",
+				"  public Test() {",
+				"  }",
+				"  protected void createPages() {",
+				"  }",
+				"  public boolean isSaveAsAllowed() {",
+				"    return false;",
+				"  }",
+				"  public void doSave(IProgressMonitor monitor) {",
+				"  }",
+				"  public void doSaveAs() {	",
+				"  }",
+				"}"));
+		assertEquals(IExceptionConstants.NO_DESIGN_MP_EDITOR, e.getCode());
+		assertTrue(DesignerExceptionUtils.isWarning(e));
 	}
 }

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PageLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/PageLayoutTest.java
@@ -349,17 +349,13 @@ public class PageLayoutTest extends RcpModelTest {
 			assertTrue(creationSupport.canReorder());
 			assertTrue(creationSupport.canReparent());
 			// this PageLayout_add_CreationSupport was created without source
-			try {
-				NodeTarget nodeTarget =
-						getNodeStatementTarget(
-								page,
-								"createInitialLayout(org.eclipse.ui.IPageLayout)",
-								false,
-								1);
-				creationSupport.add_getSource(nodeTarget);
-				fail();
-			} catch (AssertionFailedException e) {
-			}
+			NodeTarget nodeTarget =
+					getNodeStatementTarget(
+							page,
+							"createInitialLayout(org.eclipse.ui.IPageLayout)",
+							false,
+							1);
+			assertThrows(AssertionFailedException.class, () -> creationSupport.add_getSource(nodeTarget));
 		}
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ViewPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/rcp/model/rcp/ViewPartTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -167,11 +167,7 @@ public class ViewPartTest extends RcpModelTest {
 				"      {implicit-layout: absolute} {implicit-layout} {}");
 		//
 		IViewSite viewSite = (IViewSite) ReflectionUtils.invokeMethod(part.getObject(), "getViewSite()");
-		try {
-			viewSite.getShell();
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, viewSite::getShell);
 		assertEquals("IViewSite_stub", viewSite.toString());
 		assertEquals(0, viewSite.hashCode());
 		assertEquals("some.view.Identifier", viewSite.getId());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/bean/ActionTest.java
@@ -89,20 +89,16 @@ public class ActionTest extends SwingModelTest {
 	////////////////////////////////////////////////////////////////////////////
 	@Test
 	public void test_noDesign_forActions() throws Exception {
-		try {
-			parseJavaInfo("""
-					public class Test extends AbstractAction {
-						public Test() {
-							putValue(NAME, "My name");
-							putValue(SHORT_DESCRIPTION, "My short description");
-						}
-						public void actionPerformed(ActionEvent e) {
-						}
-					}""");
-			fail();
-		} catch (DesignerException e) {
-			assertEquals(IExceptionConstants.NO_DESIGN_ACTION, e.getCode());
-		}
+		DesignerException e = assertThrows(DesignerException.class, () -> parseJavaInfo("""
+				public class Test extends AbstractAction {
+					public Test() {
+						putValue(NAME, "My name");
+						putValue(SHORT_DESCRIPTION, "My short description");
+					}
+					public void actionPerformed(ActionEvent e) {
+					}
+				}"""));
+		assertEquals(IExceptionConstants.NO_DESIGN_ACTION, e.getCode());
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JToolBarTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JToolBarTest.java
@@ -316,53 +316,26 @@ public class JToolBarTest extends SwingModelTest {
 			assertEquals("void", variable.toString());
 			assertEquals("addSeparator()", variable.getTitle());
 			// target
-			try {
-				assertTarget(variable.getStatementTarget(), null, associationStatement, false);
-				fail();
-			} catch (IllegalStateException e) {
-			}
+			assertThrows(IllegalStateException.class,
+					() -> assertTarget(variable.getStatementTarget(), null, associationStatement, false));
 			// name
 			{
 				assertFalse(variable.hasName());
-				try {
-					variable.getName();
-					fail();
-				} catch (IllegalStateException e) {
-				}
-				try {
-					variable.setName("can-not-set-name");
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variable::getName);
+				assertThrows(IllegalStateException.class, () -> variable.setName("can-not-set-name"));
 			}
 			// expressions
 			{
-				try {
-					variable.getReferenceExpression((NodeTarget) null);
-					fail();
-				} catch (IllegalStateException e) {
-				}
-				try {
-					variable.getAccessExpression((NodeTarget) null);
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, () -> variable.getReferenceExpression((NodeTarget) null));
+				assertThrows(IllegalStateException.class, () -> variable.getAccessExpression((NodeTarget) null));
 			}
 			// conversion
 			{
 				assertFalse(variable.canConvertLocalToField());
-				try {
-					variable.convertLocalToField();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, () -> variable.convertLocalToField());
 				//
 				assertFalse(variable.canConvertFieldToLocal());
-				try {
-					variable.convertFieldToLocal();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variable::convertFieldToLocal);
 			}
 		}
 		// check JToolBar_Separator_CreationSupport

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/AbsoluteLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/AbsoluteLayoutTest.java
@@ -141,52 +141,20 @@ public class AbsoluteLayoutTest extends AbstractLayoutTest {
 				assertEquals("absolute", variableSupport.toString());
 				// name
 				assertFalse(variableSupport.hasName());
-				try {
-					variableSupport.getName();
-					fail();
-				} catch (IllegalStateException e) {
-				}
-				try {
-					variableSupport.setName("abc");
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variableSupport::getName);
+				assertThrows(IllegalStateException.class, () -> variableSupport.setName("abc"));
 				// expressions
-				try {
-					variableSupport.getReferenceExpression((NodeTarget) null);
-					fail();
-				} catch (IllegalStateException e) {
-				}
-				try {
-					variableSupport.getAccessExpression((NodeTarget) null);
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, () -> variableSupport.getReferenceExpression((NodeTarget) null));
+				assertThrows(IllegalStateException.class, () -> variableSupport.getAccessExpression((NodeTarget) null));
 				// conversion
 				assertFalse(variableSupport.canConvertLocalToField());
-				try {
-					variableSupport.convertLocalToField();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variableSupport::convertLocalToField);
 				assertFalse(variableSupport.canConvertFieldToLocal());
-				try {
-					variableSupport.convertFieldToLocal();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variableSupport::convertFieldToLocal);
 				// target
-				try {
-					variableSupport.getStatementTarget();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variableSupport::getStatementTarget);
 				// title
-				try {
-					variableSupport.getTitle();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, variableSupport::getTitle);
 			}
 			// association
 			assertInstanceOf(InvocationChildAssociation.class, layout.getAssociation());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/FormLayout/FormLayoutTest.java
@@ -1119,11 +1119,7 @@ public class FormLayoutTest extends AbstractFormLayoutTest {
 				"  }",
 				"}");
 		// check that layout does not have cached CellConstraintsSupport
-		try {
-			FormLayoutInfo.getConstraints(button);
-			fail();
-		} catch (AssertionFailedException e) {
-		}
+		assertThrows(AssertionFailedException.class, () -> FormLayoutInfo.getConstraints(button));
 	}
 
 	/**
@@ -1159,11 +1155,7 @@ public class FormLayoutTest extends AbstractFormLayoutTest {
 				"  }",
 				"}");
 		// check that layout does not have cached CellConstraintsSupport
-		try {
-			FormLayoutInfo.getConstraints(button);
-			fail();
-		} catch (AssertionFailedException e) {
-		}
+		assertThrows(AssertionFailedException.class, () -> FormLayoutInfo.getConstraints(button));
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/ImplicitLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/ImplicitLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -91,29 +91,13 @@ public class ImplicitLayoutTest extends AbstractLayoutTest {
 			assertEquals("(implicit layout)", variableSupport.getTitle());
 			// name
 			assertFalse(variableSupport.hasName());
-			try {
-				variableSupport.getName();
-				fail();
-			} catch (IllegalStateException e) {
-			}
-			try {
-				variableSupport.setName("foo");
-				fail();
-			} catch (IllegalStateException e) {
-			}
+			assertThrows(IllegalStateException.class, variableSupport::getName);
+			assertThrows(IllegalStateException.class, () -> variableSupport.setName("foo"));
 			// conversion
 			assertFalse(variableSupport.canConvertLocalToField());
-			try {
-				variableSupport.convertLocalToField();
-				fail();
-			} catch (IllegalStateException e) {
-			}
+			assertThrows(IllegalStateException.class, variableSupport::convertLocalToField);
 			assertFalse(variableSupport.canConvertFieldToLocal());
-			try {
-				variableSupport.convertFieldToLocal();
-				fail();
-			} catch (IllegalStateException e) {
-			}
+			assertThrows(IllegalStateException.class, variableSupport::convertFieldToLocal);
 			// target
 			{
 				StatementTarget target = variableSupport.getStatementTarget();

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutConstraintsTest.java
@@ -365,11 +365,7 @@ public class MigLayoutConstraintsTest extends AbstractMigLayoutTest {
 			assertEquals(expectedString, constraints.getString());
 		}
 		// set bad
-		try {
-			constraints.setString("somethingBad");
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> constraints.setString("somethingBad"));
 	}
 
 	private String getCellConstraintsSource(CellConstraintsSupport cell) {

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/MigLayout/MigLayoutTest.java
@@ -1001,11 +1001,7 @@ public class MigLayoutTest extends AbstractMigLayoutTest {
 
 	@Test
 	public void test_ColumnInfo_setAlignment_UNKNOWN() throws Exception {
-		try {
-			check_ColumnInfo_setAlignment(MigColumnInfo.Alignment.UNKNOWN, "not used");
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> check_ColumnInfo_setAlignment(MigColumnInfo.Alignment.UNKNOWN, "not used"));
 	}
 
 	/**
@@ -1159,11 +1155,7 @@ public class MigLayoutTest extends AbstractMigLayoutTest {
 
 	@Test
 	public void test_RowInfo_setAlignment_UNKNOWN() throws Exception {
-		try {
-			check_RowInfo_setAlignment(MigRowInfo.Alignment.UNKNOWN, "not used");
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> check_RowInfo_setAlignment(MigRowInfo.Alignment.UNKNOWN, "not used"));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagConstraintsTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/gbl/GridBagConstraintsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,6 +24,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.variable.EmptyVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.LocalUniqueVariableSupport;
 import org.eclipse.wb.internal.core.model.variable.VariableSupport;
+import org.eclipse.wb.internal.core.utils.check.AssertionFailedException;
 import org.eclipse.wb.internal.core.utils.exception.DesignerException;
 import org.eclipse.wb.internal.core.utils.exception.DesignerExceptionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -325,11 +326,7 @@ public class GridBagConstraintsTest extends AbstractGridBagLayoutTest {
 				assertInstanceOf(VirtualConstraintsVariableSupport.class, variable);
 				assertEquals("(virtual GBL constraints)", variable.getTitle());
 				assertEquals("virtual-GBL-constraints", variable.toString());
-				try {
-					variable.getStatementTarget();
-					fail();
-				} catch (IllegalStateException e) {
-				}
+				assertThrows(IllegalStateException.class, () -> variable.getStatementTarget());
 			}
 			assertInstanceOf(EmptyAssociation.class, constraints.getAssociation());
 		}
@@ -908,32 +905,24 @@ public class GridBagConstraintsTest extends AbstractGridBagLayoutTest {
 
 	@Test
 	public void test_alignments_unknownHorizontal() throws Exception {
-		try {
-			ReflectionUtils.invokeMethod2(
-					GridBagConstraintsInfo.class,
-					"getHorizontalAlignment",
-					int.class,
-					int.class,
-					-1,
-					-1);
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> ReflectionUtils.invokeMethod2(
+				GridBagConstraintsInfo.class,
+				"getHorizontalAlignment",
+				int.class,
+				int.class,
+				-1,
+				-1));
 	}
 
 	@Test
 	public void test_alignments_unknownVertical() throws Exception {
-		try {
-			ReflectionUtils.invokeMethod2(
-					GridBagConstraintsInfo.class,
-					"getVerticalAlignment",
-					int.class,
-					int.class,
-					-1,
-					-1);
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> ReflectionUtils.invokeMethod2(
+				GridBagConstraintsInfo.class,
+				"getVerticalAlignment",
+				int.class,
+				int.class,
+				-1,
+				-1));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/spring/SpringAttachmentTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/layout/spring/SpringAttachmentTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -57,11 +57,7 @@ public class SpringAttachmentTest extends AbstractLayoutTest {
 		assertSame(SpringLayout.EAST, SpringAttachmentInfo.getSpringSide(PositionConstants.RIGHT));
 		assertSame(SpringLayout.NORTH, SpringAttachmentInfo.getSpringSide(PositionConstants.TOP));
 		assertSame(SpringLayout.SOUTH, SpringAttachmentInfo.getSpringSide(PositionConstants.BOTTOM));
-		try {
-			SpringAttachmentInfo.getSpringSide(-1);
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> SpringAttachmentInfo.getSpringSide(-1));
 	}
 
 	/**
@@ -81,11 +77,7 @@ public class SpringAttachmentTest extends AbstractLayoutTest {
 		assertEquals(
 				"javax.swing.SpringLayout.SOUTH",
 				SpringAttachmentInfo.getSpringSideSource(PositionConstants.BOTTOM));
-		try {
-			SpringAttachmentInfo.getSpringSideSource(-1);
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> SpringAttachmentInfo.getSpringSideSource(-1));
 	}
 
 	/**
@@ -99,11 +91,7 @@ public class SpringAttachmentTest extends AbstractLayoutTest {
 		assertEquals(
 				PositionConstants.BOTTOM,
 				SpringAttachmentInfo.getFrameworkSide(SpringLayout.SOUTH));
-		try {
-			SpringAttachmentInfo.getFrameworkSide("no such side");
-			fail();
-		} catch (IllegalArgumentException e) {
-		}
+		assertThrows(IllegalArgumentException.class, () -> SpringAttachmentInfo.getFrameworkSide("no such side"));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/ClipboardTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/ClipboardTest.java
@@ -273,34 +273,18 @@ public class ClipboardTest extends RcpModelTest {
 		// do paste
 		ExecutionUtils.run(shell, () -> {
 			// can not apply() before create()
-			try {
-				memento.apply();
-				fail();
-			} catch (AssertionFailedException e) {
-			}
+			assertThrows(AssertionFailedException.class, memento::apply);
 			// create control
 			ControlInfo control = (ControlInfo) memento.create(shell);
 			// can not apply() before adding to hierarchy
-			try {
-				memento.apply();
-				fail();
-			} catch (IllegalArgumentException e) {
-			}
+			assertThrows(IllegalArgumentException.class, memento::apply);
 			// add
 			absoluteLayout.commandCreate(control, null);
 			memento.apply();
 			// can not apply() second time
-			try {
-				memento.apply();
-				fail();
-			} catch (IllegalArgumentException e) {
-			}
+			assertThrows(IllegalArgumentException.class, memento::apply);
 			// can not create() after apply()
-			try {
-				memento.create(shell);
-				fail();
-			} catch (IllegalArgumentException e) {
-			}
+			assertThrows(IllegalArgumentException.class, () -> memento.create(shell));
 		});
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/jface/ViewerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/jface/ViewerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -722,18 +722,16 @@ public class ViewerTest extends RcpModelTest {
 	 */
 	@Test
 	public void test_noRootComposite() throws Exception {
-		try {
+		Throwable e = assertThrows(Throwable.class, () -> {
 			parseComposite(
 					"public class Test {",
 					"  public Test(Composite parent) {",
 					"    TableViewer tableViewer = new TableViewer(parent, SWT.BORDER);",
 					"  }",
 					"}");
-			fail();
-		} catch (Throwable e) {
-			Throwable rootCause = DesignerExceptionUtils.getRootCause(e);
-			Assertions.assertThat(rootCause).isExactlyInstanceOf(NoEntryPointError.class);
-		}
+		});
+		Throwable rootCause = DesignerExceptionUtils.getRootCause(e);
+		Assertions.assertThat(rootCause).isExactlyInstanceOf(NoEntryPointError.class);
 	}
 
 	////////////////////////////////////////////////////////////////////////////

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/FillLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/FillLayoutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -106,11 +106,7 @@ public class FillLayoutTest extends RcpModelTest {
 		assertTrue(shell.getChildrenControls().isEmpty());
 		FillLayoutInfo layout = (FillLayoutInfo) shell.getLayout();
 		//
-		try {
-			ReflectionUtils.invokeMethod(layout, "getDefaultVirtualDataObject()");
-			fail();
-		} catch (NotImplementedException e) {
-		}
+		assertThrows(NotImplementedException.class, () -> ReflectionUtils.invokeMethod(layout, "getDefaultVirtualDataObject()"));
 	}
 
 	@Test

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/LayoutLayoutDataCompatibilityTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/LayoutLayoutDataCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -101,22 +101,18 @@ public class LayoutLayoutDataCompatibilityTest extends RcpModelTest {
 	 */
 	@Test
 	public void test_notCompatible() throws Exception {
-		try {
-			parseComposite(
-					"public class Test extends Shell {",
-					"  public Test() {",
-					"    setLayout(new GridLayout());",
-					"    {",
-					"      Button button = new Button(this, SWT.NONE);",
-					"      button.setLayoutData(new RowData());",
-					"    }",
-					"  }",
-					"}");
-			fail();
-		} catch (Throwable e) {
-			DesignerException de = DesignerExceptionUtils.getDesignerException(e);
-			assertEquals(IExceptionConstants.INCOMPATIBLE_LAYOUT_DATA, de.getCode());
-		}
+		Throwable e = assertThrows(Throwable.class, () -> parseComposite(
+				"public class Test extends Shell {",
+				"  public Test() {",
+				"    setLayout(new GridLayout());",
+				"    {",
+				"      Button button = new Button(this, SWT.NONE);",
+				"      button.setLayoutData(new RowData());",
+				"    }",
+				"  }",
+				"}"));
+		DesignerException de = DesignerExceptionUtils.getDesignerException(e);
+		assertEquals(IExceptionConstants.INCOMPATIBLE_LAYOUT_DATA, de.getCode());
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/VirtualLayoutDataTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/VirtualLayoutDataTest.java
@@ -92,11 +92,7 @@ public class VirtualLayoutDataTest extends RcpModelTest {
 			assertEquals("(virtual layout data)", variableSupport.getTitle());
 			assertEquals("virtual-layout-data", variableSupport.toString());
 			// can not be reference because don't have presentation in source
-			try {
-				variableSupport.getStatementTarget();
-				fail();
-			} catch (IllegalStateException e) {
-			}
+			assertThrows(IllegalStateException.class, variableSupport::getStatementTarget);
 		}
 		// check association
 		assertInstanceOf(EmptyAssociation.class, dataInfo.getAssociation());

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/ResourceManagerTest.java
@@ -164,27 +164,27 @@ public class ResourceManagerTest extends RcpModelTest {
 	@Test
 	public void test_decorateImage_wrongCorner() throws Exception {
 		// check out of range corner values to left
-		try {
-			ReflectionUtils.invokeMethod(
-					ManagerClass,
-					"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
-					null,
-					null,
-					0);
-			fail();
-		} catch (IllegalArgumentException e) {
-			assertEquals("Wrong decorate corner", e.getMessage());
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+				ReflectionUtils.invokeMethod(
+						ManagerClass,
+						"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
+						null,
+						null,
+						0);
+			});
+			assertEquals ("Wrong decorate corner", e.getMessage());
 		}
 		// check out of range corner values to right
-		try {
-			ReflectionUtils.invokeMethod(
-					ManagerClass,
-					"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
-					null,
-					null,
-					5);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+				ReflectionUtils.invokeMethod(
+						ManagerClass,
+						"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
+						null,
+						null,
+						5);
+			});
 			assertEquals("Wrong decorate corner", e.getMessage());
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/SWTResourceManagerTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/property/SWTResourceManagerTest.java
@@ -339,27 +339,27 @@ public class SWTResourceManagerTest extends RcpModelTest {
 	@Test
 	public void test_decorateImage_wrongCorner() throws Exception {
 		// check out of range corner values to left
-		try {
-			ReflectionUtils.invokeMethod(
-					SWTManagerClass,
-					"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
-					null,
-					null,
-					0);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+				ReflectionUtils.invokeMethod(
+						SWTManagerClass,
+						"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
+						null,
+						null,
+						0);
+			});
 			assertEquals("Wrong decorate corner", e.getMessage());
 		}
 		// check out of range corner values to right
-		try {
-			ReflectionUtils.invokeMethod(
-					SWTManagerClass,
-					"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
-					null,
-					null,
-					5);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+				ReflectionUtils.invokeMethod(
+						SWTManagerClass,
+						"decorateImage(org.eclipse.swt.graphics.Image,org.eclipse.swt.graphics.Image,int)",
+						null,
+						null,
+						5);
+			});
 			assertEquals("Wrong decorate corner", e.getMessage());
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/CompositeTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/widgets/CompositeTest.java
@@ -221,54 +221,22 @@ public class CompositeTest extends RcpModelTest {
 		assertEquals("absolute", variableSupport.toString());
 		// name
 		assertFalse(variableSupport.hasName());
-		try {
-			variableSupport.getName();
-			fail();
-		} catch (IllegalStateException e) {
-		}
-		try {
-			variableSupport.setName("foo");
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, variableSupport::getName);
+		assertThrows(IllegalStateException.class, () -> variableSupport.setName("foo"));
 		// title
-		try {
-			variableSupport.getTitle();
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, variableSupport::getTitle);
 		// local -> field
 		assertFalse(variableSupport.canConvertLocalToField());
-		try {
-			variableSupport.convertLocalToField();
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, variableSupport::convertLocalToField);
 		// field -> local
 		assertFalse(variableSupport.canConvertFieldToLocal());
-		try {
-			variableSupport.convertFieldToLocal();
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, variableSupport::convertFieldToLocal);
 		// target
-		try {
-			variableSupport.getStatementTarget();
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, variableSupport::getStatementTarget);
 		// reference expression
-		try {
-			variableSupport.getReferenceExpression((NodeTarget) null);
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, () -> variableSupport.getReferenceExpression((NodeTarget) null));
 		// access expression
-		try {
-			variableSupport.getAccessExpression((NodeTarget) null);
-			fail();
-		} catch (IllegalStateException e) {
-		}
+		assertThrows(IllegalStateException.class, () -> variableSupport.getAccessExpression((NodeTarget) null));
 	}
 
 	/**

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/FigureTest.java
@@ -88,12 +88,8 @@ public class FigureTest extends Draw2dFigureTestCase {
 		parentFigure.add(wrongChildFigure);
 		assertEquals(parentFigure, wrongChildFigure.getParent());
 		// assert add itself
-		try {
-			parentFigure.add(parentFigure);
-			fail();
-		} catch (IllegalArgumentException e) {
-			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
-		}
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.add(parentFigure));
+		assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 	}
 
 	@Test
@@ -137,25 +133,19 @@ public class FigureTest extends Draw2dFigureTestCase {
 		parentFigure.add(wrongChildFigure, 2);
 		assertEquals(parentFigure, wrongChildFigure.getParent());
 		// assert add itself
-		try {
-			parentFigure.add(parentFigure, 2);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.add(parentFigure, 2));
 			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 		/*
 		 * === assert wrong index ===
 		 */
-		try {
-			parentFigure.add(new Figure(), -2);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
+		{
+			IndexOutOfBoundsException e = assertThrows(IndexOutOfBoundsException.class, () -> parentFigure.add(new Figure(), -2));
 			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
-		try {
-			parentFigure.add(new Figure(), parentFigure.getChildren().size() + 1);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
+		{
+			IndexOutOfBoundsException e = assertThrows(IndexOutOfBoundsException.class, () -> parentFigure.add(new Figure(), parentFigure.getChildren().size() + 1));
 			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
 	}
@@ -196,10 +186,8 @@ public class FigureTest extends Draw2dFigureTestCase {
 		assertEquals(parentFigure, wrongChildFigure.getParent());
 
 		// assert add itself
-		try {
-			parentFigure.add(parentFigure, null);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.add(parentFigure, null));
 			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 		/*
@@ -259,25 +247,19 @@ public class FigureTest extends Draw2dFigureTestCase {
 		parentFigure.add(wrongChildFigure, null, 2);
 		assertEquals(parentFigure, wrongChildFigure.getParent());
 		// assert add itself
-		try {
-			parentFigure.add(parentFigure, null, 2);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.add(parentFigure, null, 2));
 			assertEquals(ERROR_MESSAGE_CYCLE, e.getMessage());
 		}
 		/*
 		 * === assert wrong index ===
 		 */
-		try {
-			parentFigure.add(new Figure(), null, -2);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
+		{
+			IndexOutOfBoundsException e = assertThrows(IndexOutOfBoundsException.class, () -> parentFigure.add(new Figure(), null, -2));
 			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
-		try {
-			parentFigure.add(new Figure(), null, parentFigure.getChildren().size() + 1);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
+		{
+			IndexOutOfBoundsException e = assertThrows(IndexOutOfBoundsException.class, () -> parentFigure.add(new Figure(), null, parentFigure.getChildren().size() + 1));
 			assertEquals(ERROR_MESSAGE_INVALID_INDEX, e.getMessage());
 		}
 		/*
@@ -301,24 +283,18 @@ public class FigureTest extends Draw2dFigureTestCase {
 		/*
 		 * === assert remove from empty parent ===
 		 */
-		try {
-			parentFigure.remove(null);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.remove(null));
 			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		//
-		try {
-			parentFigure.remove(new Figure());
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.remove(new Figure()));
 			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		// assert remove itself
-		try {
-			parentFigure.remove(parentFigure);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.remove(parentFigure));
 			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		/*
@@ -334,10 +310,8 @@ public class FigureTest extends Draw2dFigureTestCase {
 		/*
 		 * === assert remove alredy removed figure ===
 		 */
-		try {
-			parentFigure.remove(childFigure);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.remove(childFigure));
 			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		/*
@@ -345,17 +319,13 @@ public class FigureTest extends Draw2dFigureTestCase {
 		 */
 		Figure wrongChildFigure = new Figure();
 		new Figure().add(wrongChildFigure);
-		try {
-			parentFigure.remove(wrongChildFigure);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.remove(wrongChildFigure));
 			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 		// assert remove itself
-		try {
-			parentFigure.remove(parentFigure);
-			fail();
-		} catch (IllegalArgumentException e) {
+		{
+			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> parentFigure.remove(parentFigure));
 			assertEquals(ERROR_MESSAGE_EMPTY_PARENT, e.getMessage());
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/PolylineTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/PolylineTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -80,12 +80,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		m_actualLogger.assertEquals(m_expectedLogger);
 		//
 		// check add null point and not reset state
-		try {
-			m_polyline.addPoint(null);
-			fail();
-		} catch (NullPointerException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(NullPointerException.class, () -> m_polyline.addPoint(null));
+		m_actualLogger.assertEmpty();
 		//
 		// check work getPoint(int)
 		PointList list = m_polyline.getPoints();
@@ -99,12 +95,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 	@Test
 	public void test_insertPoint() throws Exception {
 		// check insert point with wrong index and not reset state
-		try {
-			m_polyline.insertPoint(new Point(), 1);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(IndexOutOfBoundsException.class, () -> m_polyline.insertPoint(new Point(), 1));
+		m_actualLogger.assertEmpty();
 		//
 		// check work insert point and reset state
 		m_polyline.insertPoint(new Point(), 0);
@@ -143,12 +135,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		assertEquals(new Point(-90, 0), list.getPoint(3));
 		//
 		// check insert null point index and not reset state
-		try {
-			m_polyline.insertPoint(null, 0);
-			fail();
-		} catch (NullPointerException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(NullPointerException.class, () -> m_polyline.insertPoint(null, 0));
+		m_actualLogger.assertEmpty();
 	}
 
 	@Test
@@ -162,12 +150,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		assertEquals(3, list.size());
 		//
 		// check remove point with wrong index and not reset state
-		try {
-			m_polyline.removePoint(4);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(IndexOutOfBoundsException.class, () -> m_polyline.removePoint(4));
+		m_actualLogger.assertEmpty();
 		//
 		// check remove point and reset state
 		m_polyline.removePoint(2);
@@ -200,12 +184,8 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		assertEquals(0, list.size());
 		//
 		// check remove point with wrong index and not reset state
-		try {
-			m_polyline.removePoint(0);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(IndexOutOfBoundsException.class, () -> m_polyline.removePoint(0));
+		m_actualLogger.assertEmpty();
 	}
 
 	@Test
@@ -284,28 +264,16 @@ public class PolylineTest extends Draw2dFigureTestCase {
 		m_actualLogger.clear();
 		//
 		// check work setPoint() with wrong index
-		try {
-			m_polyline.setPoint(new Point(), -1);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(IndexOutOfBoundsException.class, () -> m_polyline.setPoint(new Point(), -1));
+		m_actualLogger.assertEmpty();
 		//
 		// check work setPoint() with wrong index
-		try {
-			m_polyline.setPoint(new Point(), 2);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(IndexOutOfBoundsException.class, () -> m_polyline.setPoint(new Point(), 2));
+		m_actualLogger.assertEmpty();
 		//
 		// check work setPoint() for null point
-		try {
-			m_polyline.setPoint(null, 0);
-			fail();
-		} catch (NullPointerException e) {
-			m_actualLogger.assertEmpty();
-		}
+		assertThrows(NullPointerException.class, () -> m_polyline.setPoint(null, 0));
+		m_actualLogger.assertEmpty();
 		//
 		// check work setPoint()
 		Point point = new Point(3, 4);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/draw2d/RootFigureTest.java
@@ -198,11 +198,7 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		TestLogger expectedLogger = new TestLogger();
 		//
 		// check add null Layer
-		try {
-			testRoot.addLayer(null);
-			fail();
-		} catch (NullPointerException e) {
-		}
+		assertThrows(NullPointerException.class, () -> testRoot.addLayer(null));
 		//
 		assertEquals(0, testRoot.getLayers().size());
 		//
@@ -252,18 +248,10 @@ public class RootFigureTest extends Draw2dFigureTestCase {
 		actualLogger.clear();
 		//
 		// check remove null Layer
-		try {
-			testRoot.removeLayer((Layer) null);
-			fail();
-		} catch (NullPointerException e) {
-		}
+		assertThrows(NullPointerException.class, () -> testRoot.removeLayer((Layer) null));
 		//
 		// check remove Layer with not exist name
-		try {
-			testRoot.removeLayer("feedback");
-			fail();
-		} catch (NullPointerException e) {
-		}
+		assertThrows(NullPointerException.class, () -> testRoot.removeLayer("feedback"));
 		//
 		Layer layer1 = new Layer("feedback");
 		testRoot.addLayer(layer1);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EditPartTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/EditPartTest.java
@@ -17,6 +17,7 @@ import org.eclipse.wb.gef.core.policies.DesignEditPolicy;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
+import org.eclipse.core.runtime.AssertionFailedException;
 import org.eclipse.draw2d.EventListenerList;
 import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
@@ -112,10 +113,8 @@ public class EditPartTest extends GefTestCase {
 		/*
 		 * check add 'null' child EditPart
 		 */
-		try {
-			templatePart.test_access_addChild(null, 0);
-			fail();
-		} catch (RuntimeException e) {
+		{
+			Exception e = assertThrows(AssertionFailedException.class, () -> templatePart.test_access_addChild(null, 0));
 			assertEquals("null argument:", e.getMessage());
 		}
 		/*
@@ -126,11 +125,9 @@ public class EditPartTest extends GefTestCase {
 		/*
 		 * check add EditPart from wrong index (positive)
 		 */
-		try {
-			templatePart.test_access_addChild(testPart1, 1);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			assertTrue("Index: 1, Size: 0".equals(e.getMessage()));
+		{
+			Exception e = assertThrows(IndexOutOfBoundsException.class, () -> templatePart.test_access_addChild(testPart1, 1));
+			assertEquals("Index: 1, Size: 0", e.getMessage());
 		}
 		//
 		assertTrue(templatePart.getChildren().isEmpty());
@@ -138,11 +135,9 @@ public class EditPartTest extends GefTestCase {
 		/*
 		 * check add EditPart from wrong index (negative)
 		 */
-		try {
-			templatePart.test_access_addChild(testPart1, -2);
-			fail();
-		} catch (IndexOutOfBoundsException e) {
-			assertTrue("Index: -2, Size: 0".equals(e.getMessage()));
+		{
+			Exception e = assertThrows(IndexOutOfBoundsException.class, () -> templatePart.test_access_addChild(testPart1, -2));
+			assertEquals("Index: -2, Size: 0", e.getMessage());
 		}
 		//
 		assertTrue(templatePart.getChildren().isEmpty());
@@ -215,10 +210,9 @@ public class EditPartTest extends GefTestCase {
 		assertTrue(testEditPart.test_getEditPolicies().isEmpty());
 		//
 		// check install EditPolicy use 'null' key
-		try {
-			testEditPart.installEditPolicy(null, new TestEditPolicy());
-			fail();
-		} catch (Throwable t) {
+
+		{
+			Exception t = assertThrows(AssertionFailedException.class, () -> testEditPart.installEditPolicy(null, new TestEditPolicy()));
 			assertEquals("null argument:Edit Policies must be installed with keys", t.getMessage());
 		}
 		//


### PR DESCRIPTION
Our tests contain several blocks of the form:

```java
try {
    ....
    fail();
} catch (Exception e) {
    ...
}
```

... which can be replaced with an assertThrows(...) check.