### PR TITLE
[Draw2D] Use Draw2D Figure for RCP edit-parts/figures directly

### DIFF
--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/rcp/perspective/EditorAreaEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/rcp/perspective/EditorAreaEditPart.java
@@ -13,11 +13,11 @@
 package org.eclipse.wb.internal.rcp.gef.part.rcp.perspective;
 
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.rcp.gef.policy.rcp.perspective.PageLayoutSidesLayoutEditPolicy;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.EditorAreaInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/rcp/perspective/shortcuts/AbstractShortcutContainerEditPart.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/part/rcp/perspective/shortcuts/AbstractShortcutContainerEditPart.java
@@ -13,11 +13,11 @@
 package org.eclipse.wb.internal.rcp.gef.part.rcp.perspective.shortcuts;
 
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.rcp.model.rcp.perspective.shortcuts.AbstractShortcutContainerInfo;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/layout/StackLayoutNavigationFigure.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/gef/policy/layout/StackLayoutNavigationFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,14 +12,11 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.rcp.gef.policy.layout;
 
-import org.eclipse.wb.draw2d.Figure;
-
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.MouseEvent;
 import org.eclipse.draw2d.MouseListener;
-import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Control;
@@ -52,11 +49,7 @@ public final class StackLayoutNavigationFigure extends Figure {
 			public void mousePressed(MouseEvent event) {
 				event.consume();
 				//
-				Point location = Point.SINGLETON;
-				location.setLocation(event.x, event.y);
-				translateFromParent(location);
-				//
-				if (location.x < WIDTH) {
+				if (event.x - bounds.x < WIDTH) {
 					m_policy.showPrevComponent();
 				} else {
 					m_policy.showNextComponent();
@@ -71,9 +64,8 @@ public final class StackLayoutNavigationFigure extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
-		Rectangle r = getClientArea();
-		graphics.drawImage(m_prevImage, r.x, r.y);
-		graphics.drawImage(m_nextImage, r.x + WIDTH, r.y);
+	protected void paintFigure(Graphics graphics) {
+		graphics.drawImage(m_prevImage, bounds.x, bounds.y);
+		graphics.drawImage(m_nextImage, bounds.x + WIDTH, bounds.y);
 	}
 }


### PR DESCRIPTION
This affects the `EditorAreaEditPart`, the `StackLayoutNavigationFigure` and the `AbstractShortcutContainerEditPart`.