### PR TITLE
[Draw2D] Migrate to Draw2D Figure for several Core classes

### DIFF
--- a/org.eclipse.wb.core/.settings/.api_filters
+++ b/org.eclipse.wb.core/.settings/.api_filters
@@ -16,6 +16,26 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/wb/core/controls/palette/PaletteComposite.java" type="org.eclipse.wb.core.controls.palette.PaletteComposite">
+        <filter comment="Removal of reference to internal Figure class" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.wb.core.controls.palette.PaletteComposite"/>
+                <message_argument value="getCategoryFigure(ICategory)"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Removal of reference to internal Figure class" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.wb.core.controls.palette.PaletteComposite"/>
+                <message_argument value="getEntryFigure(DesignerContainer, DesignerEntry)"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Removal of reference to internal Figure class" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.wb.core.controls.palette.PaletteComposite"/>
+                <message_argument value="getEntryFigure(ICategory, IEntry)"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/wb/core/gef/IEditPartConfigurator.java" type="org.eclipse.wb.core.gef.IEditPartConfigurator">
         <filter comment="Restructuring of internal EditPart" id="403804204">
             <message_arguments>

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/AbstractRelativeLocator.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/AbstractRelativeLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,7 +20,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 
 /**
- * Implementation of {@link ILocator} that relocates target {@link Figure} relative to the some
+ * Implementation of {@link ILocator} that relocates target {@link IFigure} relative to the some
  * reference {@link Rectangle} using two floating-point value indicating the horizontal and vertical
  * offset from that reference {@link Rectangle}. The values (0.0, 0.0) would indicate the top-left
  * corner, while the values (1.0, 1.0) would indicate the bottom-right corner.

--- a/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/FigureUtils.java
+++ b/org.eclipse.wb.core/src-draw2d/org/eclipse/wb/draw2d/FigureUtils.java
@@ -23,7 +23,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 /**
- * Collection of utilities for {@link Figure}'s.
+ * Collection of utilities for {@link IFigure}'s.
  *
  * @author lobas_av
  * @coverage gef.draw2d
@@ -35,7 +35,7 @@ public class FigureUtils {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Removes given {@link Figure} from its parent.
+	 * Removes given {@link IFigure} from its parent.
 	 */
 	public static void removeFigure(IFigure figure) {
 		if (figure != null && figure.getParent() != null) {
@@ -49,8 +49,8 @@ public class FigureUtils {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Translates given {@link Translatable} from <code>source</code> {@link Figure} bounds
-	 * coordinates to bounds coordinates from <code>target</code> {@link Figure}.
+	 * Translates given {@link Translatable} from <code>source</code> {@link IFigure} bounds
+	 * coordinates to bounds coordinates from <code>target</code> {@link IFigure}.
 	 */
 	public static final void translateFigureToFigure(IFigure source, IFigure target,
 			Translatable translatable) {
@@ -70,7 +70,7 @@ public class FigureUtils {
 	}
 
 	/**
-	 * Translates given {@link Translatable} from this {@link Figure} bounds coordinates to absolute (
+	 * Translates given {@link Translatable} from this {@link IFigure} bounds coordinates to absolute (
 	 * {@link RootFigure} relative) coordinates.
 	 */
 	public static final void translateFigureToAbsolute(IFigure figure, Translatable translatable) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/controls/palette/PaletteComposite.java
@@ -312,13 +312,14 @@ public final class PaletteComposite extends Composite {
 	}
 
 	/**
-	 * @return the {@link Figure} used for displaying {@link ICategory}.
+	 * @return the {@link IFigure} used for displaying {@link ICategory}.
 	 * @deprecated Use {@link #getCategoryFigure(DesignerContainer)} instead. This
 	 *             method will be removed after the 2027-03 release.
+	 * @since 1.24
 	 */
 	@SuppressWarnings("removal")
 	@Deprecated(since = "3.19", forRemoval = true)
-	public org.eclipse.wb.draw2d.Figure getCategoryFigure(ICategory category) {
+	public IFigure getCategoryFigure(ICategory category) {
 		return m_categoryFigures.get(category);
 	}
 
@@ -335,19 +336,21 @@ public final class PaletteComposite extends Composite {
 	 *
 	 * @deprecated Use {@link #getEntryFigure(DesignerContainer, DesignerEntry)}
 	 *             instead. This method will be removed after the 2027-03 release.
+	 * @since 1.24
 	 */
 	@SuppressWarnings("removal")
 	@Deprecated(since = "3.19", forRemoval = true)
-	public org.eclipse.wb.draw2d.Figure getEntryFigure(ICategory category, IEntry entry) {
+	public IFigure getEntryFigure(ICategory category, IEntry entry) {
 		CategoryFigure categoryFigure = m_categoryFigures.get(category);
 		return categoryFigure.m_entryFigures.get(entry);
 	}
 
 	/**
 	 * @return the {@link IFigure} used for displaying {@link DesignerEntry}.
+	 * @since 1.24
 	 */
 	@SuppressWarnings("removal")
-	public org.eclipse.wb.draw2d.Figure getEntryFigure(DesignerContainer category, DesignerEntry entry) {
+	public IFigure getEntryFigure(DesignerContainer category, DesignerEntry entry) {
 		return getEntryFigure((ICategory) category, (IEntry) entry);
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/OutlineImageFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/figure/OutlineImageFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.eclipse.wb.core.gef.figure;
 
-import org.eclipse.wb.draw2d.Figure;
-
 import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.graphics.Color;
@@ -60,10 +59,10 @@ public final class OutlineImageFigure extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
+	protected void paintFigure(Graphics graphics) {
 		if (m_image != null) {
-			graphics.drawImage(m_image, 0, 0);
+			graphics.drawImage(m_image, bounds.x, bounds.y);
 		}
-		graphics.drawRectangle(getClientArea().getResized(-1, -1));
+		graphics.drawRectangle(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1);
 	}
 }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/part/ComponentIconEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/part/ComponentIconEditPart.java
@@ -13,11 +13,11 @@
 package org.eclipse.wb.core.gef.part;
 
 import org.eclipse.wb.core.gef.policy.selection.NonResizableSelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.core.model.description.IComponentDescription;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -55,9 +55,9 @@ public abstract class ComponentIconEditPart extends DesignEditPart {
 	protected IFigure createFigure() {
 		return new Figure() {
 			@Override
-			protected void paintClientArea(Graphics graphics) {
+			protected void paintFigure(Graphics graphics) {
 				Image image = getIcon().createImage();
-				graphics.drawImage(image, 0, 0);
+				graphics.drawImage(image, bounds.x, bounds.y);
 				image.dispose();
 			}
 		};

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContainerEditPart.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/header/HeadersContainerEditPart.java
@@ -15,10 +15,10 @@ package org.eclipse.wb.internal.core.gef.header;
 import org.eclipse.wb.core.gef.header.IHeaderMenuProvider;
 import org.eclipse.wb.core.gef.header.IHeadersProvider;
 import org.eclipse.wb.core.gef.policy.selection.EmptySelectionEditPolicy;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.gef.graphical.DesignEditPart;
 import org.eclipse.wb.internal.gef.graphical.GraphicalViewer;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Rectangle;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/DotsFeedback.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/DotsFeedback.java
@@ -13,9 +13,9 @@
 package org.eclipse.wb.internal.core.gef.policy.layout.absolute;
 
 import org.eclipse.wb.core.model.IAbstractComponentInfo;
-import org.eclipse.wb.draw2d.Figure;
 import org.eclipse.wb.draw2d.FigureUtils;
 
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Rectangle;
@@ -53,17 +53,16 @@ public class DotsFeedback<C extends IAbstractComponentInfo> extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
+	protected void paintFigure(Graphics graphics) {
 		// paint dots if needed
 		if (m_layoutEditPolicy.isShowGridFeedback()) {
-			Rectangle r = getClientArea();
 			int gridStepX = m_layoutEditPolicy.getGridStepX();
 			int gridStepY = m_layoutEditPolicy.getGridStepY();
 			// paint dots
-			int x = r.x;
-			for (int i = 0; i < r.width / gridStepX; i++) {
-				int y = r.y;
-				for (int j = 0; j < r.height / gridStepY; j++) {
+			int x = bounds.x;
+			for (int i = 0; i < bounds.width / gridStepX; i++) {
+				int y = bounds.y;
+				for (int j = 0; j < bounds.height / gridStepY; j++) {
 					graphics.drawPoint(x, y);
 					y += gridStepY;
 				}

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/LineEndFigure.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/absolute/LineEndFigure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,11 +12,9 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.core.gef.policy.layout.absolute;
 
-import org.eclipse.wb.draw2d.Figure;
-
+import org.eclipse.draw2d.Figure;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.PositionConstants;
-import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 
@@ -59,15 +57,14 @@ public class LineEndFigure extends Figure {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	@Override
-	protected void paintClientArea(Graphics graphics) {
+	protected void paintFigure(Graphics graphics) {
 		int oldAntialias = graphics.getAntialias();
 		try {
 			graphics.setAntialias(SWT.ON);
 			graphics.setForegroundColor(m_color);
 			graphics.setBackgroundColor(m_color);
 			graphics.setLineStyle(SWT.LINE_SOLID);
-			Rectangle clientArea = getClientArea();
-			graphics.fillArc(0, 0, clientArea.width, clientArea.height, m_startAngle, m_lengthAngle);
+			graphics.fillArc(bounds.x, bounds.y, bounds.width, bounds.height, m_startAngle, m_lengthAngle);
 		} finally {
 			graphics.setAntialias(oldAntialias);
 		}


### PR DESCRIPTION
This includes:
- OutlineImageFigure
- ComponentIconEditPart
- HeadersContainerEditPart
- DotsFeedback
- LineEndFigure

Additionally, several method signatures and documentation have been adapted to reference the `IFigure` interface directly.