### PR TITLE
Fix NPE in JTabbedPaneInfo if tab-item bounds are null #1509

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JTabbedPaneInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JTabbedPaneInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -145,16 +145,19 @@ public final class JTabbedPaneInfo extends ContainerInfo {
 		{
 			int tabCount = pane.getTabCount();
 			for (int i = tabCount - 1; i >= 0; i--) {
-				if (pane.getComponentAt(i) == null) {
+				if (pane.getComponentAt(i) == null || pane.getBoundsAt(i) == null) {
 					pane.remove(i);
 				}
 			}
 		}
 		// apply active component
 		{
-			ComponentInfo activeComponent = getActiveComponent();
-			if (activeComponent != null) {
-				pane.setSelectedComponent(activeComponent.getComponent());
+			ComponentInfo activeComponentInfo = getActiveComponent();
+			if (activeComponentInfo != null) {
+				Component activeComponent = activeComponentInfo.getComponent();
+				if (activeComponent != null && pane.indexOfComponent(activeComponent) != -1) {
+					pane.setSelectedComponent(activeComponent);
+				}
 			}
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTabbedPaneTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTabbedPaneTest.java
@@ -177,6 +177,43 @@ public class JTabbedPaneTest extends SwingModelTest {
 	}
 
 	/**
+	 * @see <a href="https://github.com/eclipse-windowbuilder/windowbuilder/issues/1509">here</a>
+	 */
+	@Test
+	public void test_invisibleTab() throws Exception {
+		setFileContentSrc("test/AlwaysNullTabbedPaneUI.java", getTestSource("""
+				import javax.swing.plaf.basic.BasicTabbedPaneUI;
+				class AlwaysNullTabbedPaneUI extends BasicTabbedPaneUI {
+					@Override
+					public Rectangle getTabBounds(JTabbedPane pane, int index) {
+						return null;
+					}
+				}
+				"""));
+		waitForAutoBuild();
+		ContainerInfo panel = parseContainer("""
+				class Test extends JPanel {
+					Test() {
+						JTabbedPane tabbed = new JTabbedPane() {
+							public void repaint(Rectangle r) {
+								if (r != null) {
+									super.repaint(r);
+								}
+							}
+						};
+						add(tabbed);
+						tabbed.addTab("Tab ", new JLabel());
+						tabbed.setUI(new AlwaysNullTabbedPaneUI());
+					}
+				}""");
+		refresh();
+		JTabbedPaneInfo tabbed = (JTabbedPaneInfo) panel.getChildrenComponents().get(0);
+		assertNoErrors(panel);
+		// ask tabs
+		Assertions.assertThat(tabbed.getTabs()).isEmpty();
+	}
+
+	/**
 	 * {@link JTabbedPane} can have more tabs that number of {@link ComponentInfo}s which we see.
 	 */
 	@Test


### PR DESCRIPTION
Depending on the UI (which is determined by the current LookAndFeel), the call to `getBoundsAt(int)` may return null. Such tabs must be removed from the model.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1509