### PR TITLE
Second attempt of fixing the NPE in JTabbedPaneInfo  #1509

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JTabbedPaneInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/component/JTabbedPaneInfo.java
@@ -110,8 +110,11 @@ public final class JTabbedPaneInfo extends ContainerInfo {
 			Component componentObject = pane.getComponentAt(i);
 			ComponentInfo component = (ComponentInfo) getChildByObject(componentObject);
 			if (component != null) {
-				Rectangle bounds = CoordinateUtils.get(pane.getBoundsAt(i));
-				tabs.add(new JTabbedPaneTabInfo(this, component, bounds));
+				java.awt.Rectangle awtBounds = pane.getBoundsAt(i);
+				if (awtBounds != null) {
+					Rectangle bounds = CoordinateUtils.get(pane.getBoundsAt(i));
+					tabs.add(new JTabbedPaneTabInfo(this, component, bounds));
+				}
 			}
 		}
 		//
@@ -145,19 +148,16 @@ public final class JTabbedPaneInfo extends ContainerInfo {
 		{
 			int tabCount = pane.getTabCount();
 			for (int i = tabCount - 1; i >= 0; i--) {
-				if (pane.getComponentAt(i) == null || pane.getBoundsAt(i) == null) {
+				if (pane.getComponentAt(i) == null) {
 					pane.remove(i);
 				}
 			}
 		}
 		// apply active component
 		{
-			ComponentInfo activeComponentInfo = getActiveComponent();
-			if (activeComponentInfo != null) {
-				Component activeComponent = activeComponentInfo.getComponent();
-				if (activeComponent != null && pane.indexOfComponent(activeComponent) != -1) {
-					pane.setSelectedComponent(activeComponent);
-				}
+			ComponentInfo activeComponent = getActiveComponent();
+			if (activeComponent != null) {
+				pane.setSelectedComponent(activeComponent.getComponent());
 			}
 		}
 	}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTabbedPaneTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swing/model/component/JTabbedPaneTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JTabbedPane;
@@ -210,7 +211,7 @@ public class JTabbedPaneTest extends SwingModelTest {
 		JTabbedPaneInfo tabbed = (JTabbedPaneInfo) panel.getChildrenComponents().get(0);
 		assertNoErrors(panel);
 		// ask tabs
-		Assertions.assertThat(tabbed.getTabs()).isEmpty();
+		assertEquals(tabbed.getTabs(), Collections.emptyList());
 	}
 
 	/**


### PR DESCRIPTION
This reverts 2eb57ded1ad0b169cbc088fd5ea1fd30bfc137d1 and instead follows the original proposal of simply excluding the JTabbedPaneTabInfo from the model if their bounds can't be determined.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1509