### PR TITLE
Avoid reconciler livelock if design page is shown on startup

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/DesignerEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/DesignerEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -138,7 +138,11 @@ IDesignCompositeProvider {
 	void activated() {
 		if (m_firstActivation) {
 			m_firstActivation = false;
-			m_multiMode.editorActivatedFirstTime();
+			getRootControl().getDisplay().asyncExec(() -> {
+				if (!m_multiMode.isDisposed()) {
+					m_multiMode.editorActivatedFirstTime();
+				}
+			});
 		}
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/MultiMode.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/editor/multi/MultiMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -35,6 +35,7 @@ public abstract class MultiMode implements IMultiMode {
 	protected final SourcePage m_sourcePage;
 	protected final DesignPage m_designPage;
 	protected final List<IEditorPage> m_additionalPages = new ArrayList<>();
+	private boolean m_disposed;
 
 	////////////////////////////////////////////////////////////////////////////
 	//
@@ -136,11 +137,16 @@ public abstract class MultiMode implements IMultiMode {
 	 * Disposes this {@link MultiMode}.
 	 */
 	void dispose() {
+		m_disposed = true;
 		m_sourcePage.dispose();
 		m_designPage.dispose();
 		for (IEditorPage page : m_additionalPages) {
 			page.dispose();
 		}
+	}
+
+	boolean isDisposed() {
+		return m_disposed;
 	}
 
 	/**


### PR DESCRIPTION
When the Java editor is activated for the first time, the reconciler is notified. Until this operation has finished, the editor will explicitly lock for several seconds.

The GEF editor is initialized within this phase, which causes the editor to block over and over again. Run the initialization asynchronously to make sure that the reconciler has finished by then.

See https://bugs.eclipse.org/366048