### PR TITLE
Migrate away from terminally deprecated Image constructor

### DIFF
--- a/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.linux/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.linux;singleton:=true
-Bundle-Version: 1.12.0.qualifier
+Bundle-Version: 1.12.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-PlatformFilter: (& (osgi.ws=gtk) (osgi.os=linux))

--- a/org.eclipse.wb.os.linux/pom.xml
+++ b/org.eclipse.wb.os.linux/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.linux</artifactId>
-    <version>1.12.0-SNAPSHOT</version>
+    <version>1.12.100-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
+++ b/org.eclipse.wb.os.linux/src/org/eclipse/wb/internal/os/linux/OSSupportLinux.java
@@ -239,7 +239,7 @@ public abstract class OSSupportLinux extends OSSupport {
 				offset.y -= getWidgetBounds(shell.getMenuBar()).height;
 			}
 			// draw
-			Image decoratedShellImage = new Image(display, shellBounds);
+			Image decoratedShellImage = new Image(display, shellBounds.width, shellBounds.height);
 			GC gc = new GC(decoratedShellImage);
 			// draw background
 			gc.setBackground(ColorConstants.titleBackground);

--- a/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.os.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.os.macosx;singleton:=true
-Bundle-Version: 1.10.0.qualifier
+Bundle-Version: 1.10.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-PlatformFilter: (osgi.os=macosx)

--- a/org.eclipse.wb.os.macosx/pom.xml
+++ b/org.eclipse.wb.os.macosx/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse.wb</groupId>
     <artifactId>org.eclipse.wb.os.macosx</artifactId>
-    <version>1.10.0-SNAPSHOT</version>
+    <version>1.10.100-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSXCocoa.java
+++ b/org.eclipse.wb.os.macosx/src/org/eclipse/wb/internal/os/macosx/OSSupportMacOSXCocoa.java
@@ -65,7 +65,7 @@ public abstract class OSSupportMacOSXCocoa<H extends Number> extends OSSupportMa
 				return null;
 			}
 			H view = getID(control, "view");
-			Image image = new Image(control.getDisplay(), bounds);
+			Image image = new Image(control.getDisplay(), bounds.width, bounds.height);
 			GC gc = new GC(image);
 			H context = getID(gc, "handle");
 			if (control instanceof Shell) {


### PR DESCRIPTION
Pass the width and height of the image as constructor arguments, rather than the rectangle.