### PR TITLE
Simplify GTK3 screenshot logic

### DIFF
--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/ScreenshotMaker.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/ScreenshotMaker.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Widget;
 
 import java.lang.foreign.MemorySegment;
 import java.util.HashMap;
@@ -148,7 +149,40 @@ public abstract class ScreenshotMaker {
 	 *                 model. Can be <code>null</code>.
 	 * @return the GdkPixmap* or cairo_surface_t* of {@link Shell}.
 	 */
-	protected abstract Image makeShot(Shell shell, BiConsumer<GtkWidget, Image> callback);
+	protected Image makeShot(Shell shell, BiConsumer<GtkWidget, Image> callback) {
+		return traverse(shell, callback);
+	}
+
+	private Image traverse(Widget w, BiConsumer<GtkWidget, Image> callback) {
+		GtkWidget widget = GtkWidget.from(w);
+		Image image = getImageSurface(GtkWidget.from(w));
+		if (image == null) {
+			return null;
+		}
+		if (callback != null) {
+			callback.accept(widget, image);
+		}
+		if (w instanceof Composite composite) {
+			for (Control childWidget : composite.getChildren()) {
+				Image childImage = traverse(childWidget, callback);
+				if (childImage == null) {
+					continue;
+				}
+				if (callback == null) {
+					childImage.dispose();
+				}
+			}
+		}
+		return image;
+	}
+
+	/**
+	 * Captures the given widget.
+	 *
+	 * @param widget The widget to capture
+	 * @return An image containing the visual representation of the given widget.
+	 */
+	protected abstract Image getImageSurface(GtkWidget widget);
 
 	private boolean bindImage(final Control control, final Image image) {
 		if (control.getData(OSSupport.WBP_NEED_IMAGE) != null && control.getData(OSSupport.WBP_IMAGE) == null) {

--- a/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/gtk3/GTK3ScreenshotMaker.java
+++ b/org.eclipse.wb.os.linux/src_java24/org/eclipse/wb/internal/os/linux/gtk3/GTK3ScreenshotMaker.java
@@ -27,12 +27,6 @@ import org.eclipse.wb.internal.os.linux.cairo.CairoSurface;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Widget;
-
-import java.util.function.BiConsumer;
 
 /**
  * Creates a screenshot of a given widget using the GTK3 API.
@@ -40,30 +34,7 @@ import java.util.function.BiConsumer;
 public class GTK3ScreenshotMaker extends ScreenshotMaker {
 
 	@Override
-	protected Image makeShot(Shell shell, BiConsumer<GtkWidget, Image> callback) {
-		return traverse(shell, callback);
-	}
-
-	private Image traverse(Widget widget, BiConsumer<GtkWidget, Image> callback) {
-		Image image = getImageSurface(GtkWidget.from(widget), callback);
-		if (image == null) {
-			return null;
-		}
-		if (widget instanceof Composite composite) {
-			for (Control childWidget : composite.getChildren()) {
-				Image childImage = traverse(childWidget, callback);
-				if (childImage == null) {
-					continue;
-				}
-				if (callback == null) {
-					childImage.dispose();
-				}
-			}
-		}
-		return image;
-	}
-
-	protected Image getImageSurface(GtkWidget widget, BiConsumer<GtkWidget, Image> callback) {
+	protected Image getImageSurface(GtkWidget widget) {
 		GdkWindow window = GTK3.gtk_widget_get_window(widget);
 		if (!GDK3.gdk_window_is_visible(window)) {
 			// don't deal with unmapped windows
@@ -77,10 +48,6 @@ public class GTK3ScreenshotMaker extends ScreenshotMaker {
 		GDK3.gdk_window_process_updates(window, true);
 		// take screenshot
 		Image image = createImage(window, width, height);
-		// get Java code notified
-		if (callback != null) {
-			callback.accept(widget, image);
-		}
 		// done
 		return image;
 	}


### PR DESCRIPTION
This moves the GTK-agnostic screenshot methods to the abstract base-class so that it can be re-used by the upcoming GTK4 port.

Additionally, the callback consumer is no longer passed to the `getImageSurface()` method and is instead call directly within the `traverse` method.