### PR TITLE
Deprecate `hasVirtualColumns` and `hasVirtualRows` for removal

### DIFF
--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/AbstractGridHelper.java
@@ -155,6 +155,7 @@ public abstract class AbstractGridHelper {
 	/**
 	 * Shows the grid feedback.
 	 */
+	@SuppressWarnings("removal")
 	public final void showGridFeedback() {
 		if (m_gridFigure != null) {
 			return;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/IGridInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/policy/layout/grid/IGridInfo.java
@@ -95,10 +95,11 @@ public interface IGridInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return <code>true</code> if this {@link IGridInfo} supports virtual columns. For example in
-	 *         GWT widget HTMLTable always filled with columns/rows, so virtual columns/rows don't
-	 *         exist.
+	 * @return <code>true</code> if this {@link IGridInfo} supports virtual columns.
+	 * @deprecated Always returns {@code true}. This method will be removed after
+	 *             the 2028-09 release.
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	boolean hasVirtualColumns();
 
 	/**
@@ -117,9 +118,11 @@ public interface IGridInfo {
 	//
 	////////////////////////////////////////////////////////////////////////////
 	/**
-	 * @return <code>true</code> if this {@link IGridInfo} supports virtual rows. For example in GWT
-	 *         widget HTMLTable always filled with columns/rows, so virtual columns/rows don't exist.
+	 * @return <code>true</code> if this {@link IGridInfo} supports virtual rows.
+	 * @deprecated Always returns {@code true}. This method will be removed after
+	 *             the 2028-09 release.
 	 */
+	@Deprecated(since = "2026-09", forRemoval = true)
 	boolean hasVirtualRows();
 
 	/**

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapLayoutInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/forms/layout/table/TableWrapLayoutInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -1065,6 +1065,7 @@ IPreferenceConstants {
 			//
 			////////////////////////////////////////////////////////////////////////////
 			@Override
+			@Deprecated
 			public boolean hasVirtualColumns() {
 				return true;
 			}
@@ -1085,6 +1086,7 @@ IPreferenceConstants {
 			//
 			////////////////////////////////////////////////////////////////////////////
 			@Override
+			@Deprecated
 			public boolean hasVirtualRows() {
 				return true;
 			}

--- a/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing.FormLayout/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing.FormLayout;singleton:=true
-Bundle-Version: 1.13.100.qualifier
+Bundle-Version: 1.13.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.FormLayout.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/FormLayoutInfo.java
+++ b/org.eclipse.wb.swing.FormLayout/src/org/eclipse/wb/internal/swing/FormLayout/model/FormLayoutInfo.java
@@ -1606,6 +1606,7 @@ public final class FormLayoutInfo extends LayoutInfo implements IPreferenceConst
 			//
 			////////////////////////////////////////////////////////////////////////////
 			@Override
+			@Deprecated
 			public boolean hasVirtualColumns() {
 				return true;
 			}
@@ -1626,6 +1627,7 @@ public final class FormLayoutInfo extends LayoutInfo implements IPreferenceConst
 			//
 			////////////////////////////////////////////////////////////////////////////
 			@Override
+			@Deprecated
 			public boolean hasVirtualRows() {
 				return true;
 			}

--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swt;singleton:=true
-Bundle-Version: 1.11.100.qualifier
+Bundle-Version: 1.11.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swt.Activator
 Bundle-Vendor: %providerName

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridLayoutInfo.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/grid/GridLayoutInfo.java
@@ -1194,6 +1194,7 @@ IGridLayoutInfo<ControlInfo> {
 			//
 			////////////////////////////////////////////////////////////////////////////
 			@Override
+			@Deprecated
 			public boolean hasVirtualColumns() {
 				return true;
 			}
@@ -1214,6 +1215,7 @@ IGridLayoutInfo<ControlInfo> {
 			//
 			////////////////////////////////////////////////////////////////////////////
 			@Override
+			@Deprecated
 			public boolean hasVirtualRows() {
 				return true;
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/swt/model/layouts/grid/GridLayoutTest.java
@@ -286,6 +286,7 @@ public class GridLayoutTest extends RcpModelTest {
 	 * Test for {@link IGridInfo}.
 	 */
 	@Test
+	@SuppressWarnings("removal")
 	public void test_gridInfo() throws Exception {
 		CompositeInfo shell = parseComposite("""
 				class Test extends Shell {


### PR DESCRIPTION
With the removal of GWT support, these methods now always return `true`.