### PR TITLE
Print scheduled jobs if type can't be selected in "Open Type" dialog

### DIFF
--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/gef/UiContext.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.tests.gef;
 
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.swt.finder.SWTBot;
@@ -76,6 +77,12 @@ public class UiContext {
 					System.err.println("Shells:");
 					for (Shell shell : Display.getCurrent().getShells()) {
 						System.err.println(shell);
+					}
+
+					System.err.println("Jobs:");
+					Job[] jobs = Job.getJobManager().find(null);
+					for (Job job : jobs) {
+						System.err.println("%s (%s) - %d".formatted(job.getName(), job.getJobGroup(), job.getState()));
 					}
 				});
 				e.printStackTrace();


### PR DESCRIPTION
Some tests sporadically fail because this dialog is empty. Likely because a dependent JDT job is still waiting.