### PR TITLE
Add StringUtitilites.removeStart()

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2024 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -197,7 +197,7 @@ public final class FlowContainerFactory {
 	}
 
 	private static AssociationObjectFactory getAssociation_invocationChild(String associationString) {
-		associationString = associationString.replaceFirst("^invocationChild ", "");
+		associationString = StringUtils.removeStart(associationString, "invocationChild ");
 		Assert.isTrue(
 				associationString.startsWith("%parent%."),
 				"Association 'invocationChild' should start with %%parent%%., but '%s' found.",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/FlowContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.core.model.association.AssociationObjectFactory;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.util.predicate.AlwaysPredicate;
 import org.eclipse.wb.internal.core.model.util.predicate.ExpressionPredicate;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 
@@ -197,7 +198,7 @@ public final class FlowContainerFactory {
 	}
 
 	private static AssociationObjectFactory getAssociation_invocationChild(String associationString) {
-		associationString = StringUtils.removeStart(associationString, "invocationChild ");
+		associationString = StringUtilities.removeStart(associationString, "invocationChild ");
 		Assert.isTrue(
 				associationString.startsWith("%parent%."),
 				"Association 'invocationChild' should start with %%parent%%., but '%s' found.",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/SimpleContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/SimpleContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -139,7 +139,7 @@ public final class SimpleContainerFactory {
 	}
 
 	private static AssociationObjectFactory getAssociation_invocationChild(String associationString) {
-		associationString = associationString.replaceFirst("^invocationChild ", "");
+		associationString = StringUtils.removeStart(associationString, "invocationChild ");
 		Assert.isTrue(
 				associationString.startsWith("%parent%."),
 				"Association 'invocationChild' should start with '%%parent%%.', but '%s' found.",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/SimpleContainerFactory.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/generic/SimpleContainerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,6 +16,7 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.association.AssociationObjectFactories;
 import org.eclipse.wb.core.model.association.AssociationObjectFactory;
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
 import org.apache.commons.lang3.StringUtils;
@@ -139,7 +140,7 @@ public final class SimpleContainerFactory {
 	}
 
 	private static AssociationObjectFactory getAssociation_invocationChild(String associationString) {
-		associationString = StringUtils.removeStart(associationString, "invocationChild ");
+		associationString = StringUtilities.removeStart(associationString, "invocationChild ");
 		Assert.isTrue(
 				associationString.startsWith("%parent%."),
 				"Association 'invocationChild' should start with '%%parent%%.', but '%s' found.",

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2024 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -92,7 +92,7 @@ final class ListenerInfo {
 	private static String _getListenerSimpleName(Method addListenerMethod) {
 		String name = addListenerMethod.getName();
 		// convert into simple name
-		name = name.replaceFirst("^add", "");
+		name = StringUtils.removeStart(name, "add");
 		name = StringUtils.removeEnd(name, "Listener");
 		name = StringUtils.removeEnd(name, "Handler");
 		name = StringUtils.uncapitalize(name);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.core.model.property.event;
 
 import org.eclipse.wb.internal.core.utils.GenericTypeResolver;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
 
 import org.apache.commons.collections4.MultiValuedMap;
@@ -92,7 +93,7 @@ final class ListenerInfo {
 	private static String _getListenerSimpleName(Method addListenerMethod) {
 		String name = addListenerMethod.getName();
 		// convert into simple name
-		name = StringUtils.removeStart(name, "add");
+		name = StringUtilities.removeStart(name, "add");
 		name = StringUtils.removeEnd(name, "Listener");
 		name = StringUtils.removeEnd(name, "Handler");
 		name = StringUtils.uncapitalize(name);

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,6 +19,7 @@ import org.eclipse.wb.internal.core.model.property.GenericPropertyImpl;
 import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 import org.eclipse.wb.internal.core.model.util.PropertyUtils;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.state.EditorWarning;
 
 import org.apache.commons.lang3.StringUtils;
@@ -51,13 +52,13 @@ public abstract class CopyPropertyTopAbstractSupport {
 				String[] parts = StringUtils.split(parameter);
 				for (String part : parts) {
 					if (part.startsWith("from=")) {
-						sourcePath = StringUtils.removeStart(part, "from=");
+						sourcePath = StringUtilities.removeStart(part, "from=");
 					}
 					if (part.startsWith("to=")) {
-						copyTitle = StringUtils.removeStart(part, "to=");
+						copyTitle = StringUtilities.removeStart(part, "to=");
 					}
 					if (part.startsWith("category=")) {
-						String categoryText = StringUtils.removeStart(part, "category=");
+						String categoryText = StringUtilities.removeStart(part, "category=");
 						category = PropertyCategory.get(categoryText, category);
 					}
 				}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/CopyPropertyTopAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2023 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -51,13 +51,13 @@ public abstract class CopyPropertyTopAbstractSupport {
 				String[] parts = StringUtils.split(parameter);
 				for (String part : parts) {
 					if (part.startsWith("from=")) {
-						sourcePath = part.substring("from=".length());
+						sourcePath = StringUtils.removeStart(part, "from=");
 					}
 					if (part.startsWith("to=")) {
-						copyTitle = part.substring("to=".length());
+						copyTitle = StringUtils.removeStart(part, "to=");
 					}
 					if (part.startsWith("category=")) {
-						String categoryText = part.substring("category=".length());
+						String categoryText = StringUtils.removeStart(part, "category=");
 						category = PropertyCategory.get(categoryText, category);
 					}
 				}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,6 +19,7 @@ import org.eclipse.wb.internal.core.model.property.Property;
 import org.eclipse.wb.internal.core.model.property.category.PropertyCategory;
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.StringListPropertyEditor;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.execution.RunnableEx;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
@@ -133,27 +134,27 @@ abstract class ModelMethodPropertyAbstractSupport {
 		////////////////////////////////////////////////////////////////////////////
 		protected void processParameterPart(String part) throws Exception {
 			if (part.startsWith("getter=")) {
-				getterSignature = StringUtils.removeStart(part, "getter=");
+				getterSignature = StringUtilities.removeStart(part, "getter=");
 			}
 			if (part.startsWith("setter=")) {
-				setterSignature = StringUtils.removeStart(part, "setter=");
+				setterSignature = StringUtilities.removeStart(part, "setter=");
 			}
 			if (part.startsWith("type=")) {
-				String typeName = StringUtils.removeStart(part, "type=");
+				String typeName = StringUtilities.removeStart(part, "type=");
 				type = ReflectionUtils.getClassByName(GlobalState.getClassLoader(), typeName);
 				if (propertyEditor == null) {
 					propertyEditor = GlobalState.getDescriptionHelper().getEditorForType(type);
 				}
 			}
 			if (part.startsWith("editor=")) {
-				String desc = StringUtils.removeStart(part, "editor=");
+				String desc = StringUtilities.removeStart(part, "editor=");
 				parseEditor(desc);
 			}
 			if (part.startsWith("title=")) {
-				title = StringUtils.removeStart(part, "title=");
+				title = StringUtilities.removeStart(part, "title=");
 			}
 			if (part.startsWith("category=")) {
-				String categoryText = StringUtils.removeStart(part, "category=");
+				String categoryText = StringUtilities.removeStart(part, "category=");
 				category = PropertyCategory.get(categoryText, category);
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyAbstractSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyAbstractSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -133,27 +133,27 @@ abstract class ModelMethodPropertyAbstractSupport {
 		////////////////////////////////////////////////////////////////////////////
 		protected void processParameterPart(String part) throws Exception {
 			if (part.startsWith("getter=")) {
-				getterSignature = part.substring("getter=".length());
+				getterSignature = StringUtils.removeStart(part, "getter=");
 			}
 			if (part.startsWith("setter=")) {
-				setterSignature = part.substring("setter=".length());
+				setterSignature = StringUtils.removeStart(part, "setter=");
 			}
 			if (part.startsWith("type=")) {
-				String typeName = part.substring("type=".length());
+				String typeName = StringUtils.removeStart(part, "type=");
 				type = ReflectionUtils.getClassByName(GlobalState.getClassLoader(), typeName);
 				if (propertyEditor == null) {
 					propertyEditor = GlobalState.getDescriptionHelper().getEditorForType(type);
 				}
 			}
 			if (part.startsWith("editor=")) {
-				String desc = part.substring("editor=".length());
+				String desc = StringUtils.removeStart(part, "editor=");
 				parseEditor(desc);
 			}
 			if (part.startsWith("title=")) {
-				title = part.substring("title=".length());
+				title = StringUtils.removeStart(part, "title=");
 			}
 			if (part.startsWith("category=")) {
-				String categoryText = part.substring("category=".length());
+				String categoryText = StringUtils.removeStart(part, "category=");
 				category = PropertyCategory.get(categoryText, category);
 			}
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyChildSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyChildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,8 +14,7 @@ package org.eclipse.wb.internal.core.model.util.generic;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
-
-import org.apache.commons.lang3.StringUtils;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 
 /**
  * This helper allows to create top-level {@link Property} that as wrapper for some
@@ -60,7 +59,7 @@ public final class ModelMethodPropertyChildSupport extends ModelMethodPropertyAb
 			protected void processParameterPart(String part) throws Exception {
 				super.processParameterPart(part);
 				if (part.startsWith("child=")) {
-					m_childTypeName = StringUtils.removeStart(part, "child=");
+					m_childTypeName = StringUtilities.removeStart(part, "child=");
 				}
 			}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyChildSupport.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/util/generic/ModelMethodPropertyChildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,8 @@ package org.eclipse.wb.internal.core.model.util.generic;
 
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.internal.core.model.property.Property;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This helper allows to create top-level {@link Property} that as wrapper for some
@@ -58,7 +60,7 @@ public final class ModelMethodPropertyChildSupport extends ModelMethodPropertyAb
 			protected void processParameterPart(String part) throws Exception {
 				super.processParameterPart(part);
 				if (part.startsWith("child=")) {
-					m_childTypeName = part.substring("child=".length());
+					m_childTypeName = StringUtils.removeStart(part, "child=");
 				}
 			}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -185,7 +185,7 @@ public class CodeUtils {
 		String tag = preferences.getString(name);
 		tag = tag.trim();
 		// remove leading "//" prefix to search even "// $hide" - formatted line comments
-		tag = tag.replaceFirst("^//", "");
+		tag = StringUtils.removeStart(tag, "//");
 		return tag;
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.eclipse.wb.internal.core.utils.jdt.core;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
 import org.eclipse.wb.internal.core.preferences.IPreferenceConstants;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 import org.eclipse.wb.internal.core.utils.pde.ReflectivePDE;
@@ -185,7 +186,7 @@ public class CodeUtils {
 		String tag = preferences.getString(name);
 		tag = tag.trim();
 		// remove leading "//" prefix to search even "// $hide" - formatted line comments
-		tag = StringUtils.removeStart(tag, "//");
+		tag = StringUtilities.removeStart(tag, "//");
 		return tag;
 	}
 

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/ProjectReportEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/ProjectReportEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.core.editor.errors.report2;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -21,7 +22,6 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.InputStream;
@@ -80,7 +80,7 @@ public final class ProjectReportEntry implements IReportEntry {
 					// remove leading slash
 					String filePath =
 							"project/"
-									+ StringUtils.removeStart(file.getFullPath().toPortableString(), File.separator);
+									+ StringUtilities.removeStart(file.getFullPath().toPortableString(), File.separator);
 					zipStream.putNextEntry(new ZipEntry(filePath));
 					try {
 						IOUtils.copy(fileStream, zipStream);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/ProjectReportEntry.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/ProjectReportEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.InputStream;
@@ -77,11 +78,9 @@ public final class ProjectReportEntry implements IReportEntry {
 					IFile file = (IFile) resource;
 					InputStream fileStream = file.getContents();
 					// remove leading slash
-					String filePath = file.getFullPath().toPortableString();
-					if (filePath.startsWith(File.separator)) {
-						filePath = filePath.substring(File.separator.length());
-					}
-					filePath = "project/" + filePath;
+					String filePath =
+							"project/"
+									+ StringUtils.removeStart(file.getFullPath().toPortableString(), File.separator);
 					zipStream.putNextEntry(new ZipEntry(filePath));
 					try {
 						IOUtils.copy(fileStream, zipStream);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.core.model.property.category;
 
 import org.eclipse.wb.internal.core.model.property.Property;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
 import org.apache.commons.lang3.StringUtils;
@@ -110,7 +111,7 @@ public final class PropertyCategory {
 		// system
 		if (StringUtils.startsWith(text, "system(")) {
 			String systemText = text;
-			systemText = StringUtils.removeStart(systemText, "system(");
+			systemText = StringUtilities.removeStart(systemText, "system(");
 			systemText = StringUtils.removeEnd(systemText, ")");
 			try {
 				int priority = Integer.parseInt(systemText);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
@@ -110,7 +110,7 @@ public final class PropertyCategory {
 		// system
 		if (StringUtils.startsWith(text, "system(")) {
 			String systemText = text;
-			systemText = systemText.substring("system(".length());
+			systemText = StringUtils.removeStart(systemText, "system(");
 			systemText = StringUtils.removeEnd(systemText, ")");
 			try {
 				int priority = Integer.parseInt(systemText);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/StringUtilities.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/StringUtilities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.eclipse.wb.internal.core.utils;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.text.StringEscapeUtils;
 
 import java.nio.charset.CharsetEncoder;
@@ -439,5 +440,23 @@ public class StringUtilities {
 	 */
 	public static boolean isLatinCharacter(char c) {
 		return c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z';
+	}
+
+	/**
+	 * Removes a substring only if it is at the beginning of a source string,
+	 * otherwise returns the source string.
+	 *
+	 * <p>
+	 * A {@code null} source string will return {@code null}. An empty ("") source
+	 * string will return the empty string. A {@code null} search string will return
+	 * the source string.
+	 *
+	 * @param str    the source String to search, may be {@code null}.
+	 * @param remove the String to search for and remove, may be {@code null}.
+	 * @return the substring with the string removed if found, {@code null} if null
+	 *         String input.
+	 */
+	public static String removeStart(String str, String remove) {
+		return Strings.CS.removeStart(str, remove);
 	}
 }

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.rcp.databinding;singleton:=true
-Bundle-Version: 1.11.100.qualifier
+Bundle-Version: 1.11.200.qualifier
 Bundle-Activator: org.eclipse.wb.internal.rcp.databinding.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",

--- a/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.rcp.databinding/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.300,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.20.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.25.0,2.0.0)",
  org.eclipse.wb.core.java;bundle-version="[1.15.0,2.0.0)",
  org.eclipse.wb.swt;bundle-version="[1.10.100,2.0.0)",
  org.eclipse.wb.rcp;bundle-version="[1.9.1100,2.0.0)",

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
@@ -198,11 +198,8 @@ public class ControllerSupport {
 		String reference = JavaInfoReferenceProvider.getReference(javaInfo);
 		String fieldPrefix = JavaCore.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES);
 		fieldPrefix = fieldPrefix == null ? "m_" : fieldPrefix;
-		String methodName = reference;
-		if (methodName.startsWith(fieldPrefix)) {
-			methodName = methodName.substring(fieldPrefix.length());
-		}
-		methodName = "get" + StringUtils.capitalize(methodName) + "()";
+		String methodName =
+				"get" + StringUtils.capitalize(StringUtils.removeStart(reference, fieldPrefix)) + "()";
 		// prepare method header
 		String header =
 				"public " + javaInfo.getDescription().getComponentClass().getName() + " " + methodName;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/ControllerSupport.java
@@ -23,6 +23,7 @@ import org.eclipse.wb.internal.core.databinding.wizards.autobindings.AbstractDes
 import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.variable.FieldUniqueVariableSupport;
 import org.eclipse.wb.internal.core.utils.IOUtils2;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.BodyDeclarationTarget;
@@ -199,7 +200,7 @@ public class ControllerSupport {
 		String fieldPrefix = JavaCore.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES);
 		fieldPrefix = fieldPrefix == null ? "m_" : fieldPrefix;
 		String methodName =
-				"get" + StringUtils.capitalize(StringUtils.removeStart(reference, fieldPrefix)) + "()";
+				"get" + StringUtils.capitalize(StringUtilities.removeStart(reference, fieldPrefix)) + "()";
 		// prepare method header
 		String header =
 				"public " + javaInfo.getDescription().getComponentClass().getName() + " " + methodName;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2023 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -120,7 +120,7 @@ public class BeanBindableInfo extends BindableInfo {
 				}
 			}
 		} else {
-			String localReference = reference.replaceFirst("^\"", "");
+			String localReference = StringUtils.removeStart(reference, "\"");
 			localReference = StringUtils.removeEnd(localReference, "\"");
 			return resolvePropertyReference(reference, StringUtils.split(localReference, "."), 0);
 		}
@@ -140,7 +140,7 @@ public class BeanBindableInfo extends BindableInfo {
 			String localReference = references[index];
 			//
 			for (PropertyBindableInfo property : getProperties()) {
-				String propertyReference = property.getReference().replaceFirst("^\"", "");
+				String propertyReference = StringUtils.removeStart(property.getReference(), "\"");
 				propertyReference = StringUtils.removeEnd(propertyReference, "\"");
 				int pointIndex = propertyReference.lastIndexOf('.');
 				//

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.reference.IReferenceProvider;
 import org.eclipse.wb.internal.core.databinding.ui.ObserveType;
 import org.eclipse.wb.internal.core.databinding.utils.CoreUtils;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.rcp.databinding.model.BindableInfo;
 
 import org.apache.commons.lang3.StringUtils;
@@ -120,7 +121,7 @@ public class BeanBindableInfo extends BindableInfo {
 				}
 			}
 		} else {
-			String localReference = StringUtils.removeStart(reference, "\"");
+			String localReference = StringUtilities.removeStart(reference, "\"");
 			localReference = StringUtils.removeEnd(localReference, "\"");
 			return resolvePropertyReference(reference, StringUtils.split(localReference, "."), 0);
 		}
@@ -140,7 +141,7 @@ public class BeanBindableInfo extends BindableInfo {
 			String localReference = references[index];
 			//
 			for (PropertyBindableInfo property : getProperties()) {
-				String propertyReference = StringUtils.removeStart(property.getReference(), "\"");
+				String propertyReference = StringUtilities.removeStart(property.getReference(), "\"");
 				propertyReference = StringUtils.removeEnd(propertyReference, "\"");
 				int pointIndex = propertyReference.lastIndexOf('.');
 				//

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -15,6 +15,7 @@ package org.eclipse.wb.internal.rcp.databinding.model.beans.bindables;
 import org.eclipse.wb.internal.core.databinding.model.IObserveInfo;
 import org.eclipse.wb.internal.core.databinding.model.IObservePresentation;
 import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObservePresentation;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
 import org.apache.commons.lang3.StringUtils;
@@ -58,7 +59,7 @@ public final class BeanPropertyDescriptorBindableInfo extends BeanPropertyBindab
 			String reference,
 			Class<?> objectType) throws Exception {
 		if (parent instanceof BeanPropertyDescriptorBindableInfo bindableParent) {
-			String parentReference = StringUtils.removeStart(bindableParent.getReference(), "\"");
+			String parentReference = StringUtilities.removeStart(bindableParent.getReference(), "\"");
 			parentReference = StringUtils.removeEnd(parentReference, "\"");
 			//
 			final String bindingReference = parentReference + "." + reference;

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2023 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,7 +58,7 @@ public final class BeanPropertyDescriptorBindableInfo extends BeanPropertyBindab
 			String reference,
 			Class<?> objectType) throws Exception {
 		if (parent instanceof BeanPropertyDescriptorBindableInfo bindableParent) {
-			String parentReference = bindableParent.getReference().replaceFirst("^\"", "");
+			String parentReference = StringUtils.removeStart(bindableParent.getReference(), "\"");
 			parentReference = StringUtils.removeEnd(parentReference, "\"");
 			//
 			final String bindingReference = parentReference + "." + reference;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingRewriteProcessor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingRewriteProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2024 Google, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,6 +28,8 @@ import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Changes known unsupported patterns into supported.
@@ -94,7 +96,7 @@ public final class SwingRewriteProcessor {
 						"java.awt.Container",
 						"setLayout(java.awt.LayoutManager)")) {
 					String superSource = editor.getSource(node);
-					String source = superSource.replaceFirst("^super\\.", "");
+					String source = StringUtils.removeStart(superSource, "super.");
 					editor.replaceExpression(node, source);
 				}
 			}

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingRewriteProcessor.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/parser/SwingRewriteProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.wb.internal.swing.parser;
 
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.AstVisitorEx;
@@ -28,8 +29,6 @@ import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Changes known unsupported patterns into supported.
@@ -96,7 +95,7 @@ public final class SwingRewriteProcessor {
 						"java.awt.Container",
 						"setLayout(java.awt.LayoutManager)")) {
 					String superSource = editor.getSource(node);
-					String source = StringUtils.removeStart(superSource, "super.");
+					String source = StringUtilities.removeStart(superSource, "super.");
 					editor.replaceExpression(node, source);
 				}
 			}

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
@@ -99,9 +99,7 @@ public class Replacer {
 					System.exit(0);
 				}
 				// begin/end
-				if (invocation.startsWith(begin)) {
-					invocation = invocation.substring(begin.length());
-				}
+				invocation = StringUtils.removeStart(invocation, begin);
 				invocation = StringUtils.removeEnd(invocation, end);
 				//invocation = "createTypeDeclaration_Test0(" + invocation + "\")";
 				invocation = "createTypeDeclaration_Test0(" + invocation;

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.tests.designer.tests;
 
 import org.eclipse.wb.internal.core.utils.IOUtils2;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -99,7 +100,7 @@ public class Replacer {
 					System.exit(0);
 				}
 				// begin/end
-				invocation = StringUtils.removeStart(invocation, begin);
+				invocation = StringUtilities.removeStart(invocation, begin);
 				invocation = StringUtils.removeEnd(invocation, end);
 				//invocation = "createTypeDeclaration_Test0(" + invocation + "\")";
 				invocation = "createTypeDeclaration_Test0(" + invocation;
@@ -157,7 +158,7 @@ public class Replacer {
   				System.exit(0);
   			}
   			// begin/end
-  			invocation = StringUtils.removeStart(invocation, begin);
+  			invocation = StringUtilities.removeStart(invocation, begin);
   			invocation = StringUtils.removeEnd(invocation, end);
   			invocation = "assertEditor(\"" + invocation + '"';
   			// replace " with '
@@ -194,7 +195,7 @@ public class Replacer {
   		{
   			String invocation = s.substring(invocationBegin, invocationEnd);
   			// begin/end
-  			invocation = StringUtils.removeStart(invocation, begin);
+  			invocation = StringUtilities.removeStart(invocation, begin);
   			invocation = StringUtils.removeEnd(invocation, "}");
   			invocation = "parseComposite("// filler filler filler", " + invocation;
   			// replace " with '

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/StringUtilitiesTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/StringUtilitiesTest.java
@@ -296,4 +296,15 @@ public class StringUtilitiesTest extends DesignerTestCase {
 		assertEquals("ab", StringUtilities.removeNonLatinCharacters("a\u0410b"));
 		assertEquals("abc", StringUtilities.removeNonLatinCharacters("a@b.c"));
 	}
+
+	@Test
+	public void test_removeStart() {
+		assertEquals(null, StringUtilities.removeStart(null, "*"));
+		assertEquals("", StringUtilities.removeStart("", "*"));
+		assertEquals("*", StringUtilities.removeStart("*", null));
+		assertEquals("domain.com", StringUtilities.removeStart("www.domain.com", "www."));
+		assertEquals("domain.com", StringUtilities.removeStart("domain.com", "www."));
+		assertEquals("www.domain.com", StringUtilities.removeStart("www.domain.com", "domain"));
+		assertEquals("abc", StringUtilities.removeStart("abc", ""));
+	}
 }


### PR DESCRIPTION
This encapsulates the call to StringUtils, to avoid further issues in case they try to do something silly, like deprecating methods that are used in almost every project.