### PR TITLE
Add StringUtitilites.removeEnd()

### DIFF
--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/description/helpers/ComponentDescriptionHelper.java
@@ -79,6 +79,7 @@ import org.eclipse.wb.internal.core.model.description.rules.StandardBeanProperti
 import org.eclipse.wb.internal.core.model.description.rules.StandardBeanPropertyTagRule;
 import org.eclipse.wb.internal.core.model.description.rules.ToolkitRule;
 import org.eclipse.wb.internal.core.model.property.editor.PropertyEditor;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.AstNodeUtils;
 import org.eclipse.wb.internal.core.utils.ast.AstParser;
@@ -458,7 +459,7 @@ public final class ComponentDescriptionHelper {
 				buffer.append(AstParser.getDefaultValue(parameterName));
 				buffer.append(", ");
 			}
-			arguments = StringUtils.removeEnd(buffer.toString(), ", ");
+			arguments = StringUtilities.removeEnd(buffer.toString(), ", ");
 		}
 		// prepare source
 		return "new " + componentClassName + "(" + arguments + ")";

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/model/property/event/ListenerInfo.java
@@ -94,8 +94,8 @@ final class ListenerInfo {
 		String name = addListenerMethod.getName();
 		// convert into simple name
 		name = StringUtilities.removeStart(name, "add");
-		name = StringUtils.removeEnd(name, "Listener");
-		name = StringUtils.removeEnd(name, "Handler");
+		name = StringUtilities.removeEnd(name, "Listener");
+		name = StringUtilities.removeEnd(name, "Handler");
 		name = StringUtils.uncapitalize(name);
 		// if become empty, use full name
 		if (name.length() == 0) {
@@ -112,8 +112,8 @@ final class ListenerInfo {
 		// -Listener/Handler +Adapter
 		{
 			String adapterClassName = listenerType.getName();
-			adapterClassName = StringUtils.removeEnd(adapterClassName, "Listener");
-			adapterClassName = StringUtils.removeEnd(adapterClassName, "Handler");
+			adapterClassName = StringUtilities.removeEnd(adapterClassName, "Listener");
+			adapterClassName = StringUtilities.removeEnd(adapterClassName, "Handler");
 			adapterClassName = adapterClassName + "Adapter";
 			adapterType = _getExistingType(listenerType, adapterClassName);
 		}

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/ast/AstEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -170,7 +170,7 @@ public final class AstEditor {
 	 */
 	public TypeDeclaration getPrimaryType() {
 		String unitName = m_modelUnit.getElementName();
-		String typeName = StringUtils.removeEnd(unitName, ".java");
+		String typeName = StringUtilities.removeEnd(unitName, ".java");
 		return AstNodeUtils.getTypeByName(m_astUnit, typeName);
 	}
 

--- a/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
+++ b/org.eclipse.wb.core.java/src/org/eclipse/wb/internal/core/utils/jdt/core/CodeUtils.java
@@ -201,7 +201,7 @@ public class CodeUtils {
 	 */
 	public static IType findPrimaryType(ICompilationUnit compilationUnit) {
 		String unitName = compilationUnit.getElementName();
-		String typeName = StringUtils.removeEnd(unitName, ".java");
+		String typeName = StringUtilities.removeEnd(unitName, ".java");
 		IType primaryType = compilationUnit.getType(typeName);
 		if (primaryType.exists()) {
 			return primaryType;

--- a/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/MatchingEditPartFactory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/core/gef/MatchingEditPartFactory.java
@@ -13,6 +13,7 @@
 package org.eclipse.wb.core.gef;
 
 import org.eclipse.wb.gef.core.IEditPartFactory;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.check.Assert;
 
 import org.eclipse.gef.EditPart;
@@ -140,7 +141,7 @@ public final class MatchingEditPartFactory implements IEditPartFactory {
 				// prepare name of component, strip model package and "Info" suffix
 				String componentName = modelClassName;
 				componentName = componentName.substring(modelPackage.length());
-				componentName = StringUtils.removeEnd(componentName, modelSuffix);
+				componentName = StringUtilities.removeEnd(componentName, modelSuffix);
 				// create corresponding EditPart, use "EditPart" prefix
 				{
 					String partClassName = partPackage + componentName + "EditPart";

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/EnvironmentFileReportInfo.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/editor/errors/report2/EnvironmentFileReportInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -123,7 +123,7 @@ public final class EnvironmentFileReportInfo extends FileReportEntry {
 		//        }
 		//      }
 		//      // remove trailing path separator
-		//      classPath = StringUtils.removeEnd(classPath, File.pathSeparator);
+		//      classPath = StringUtilities.removeEnd(classPath, File.pathSeparator);
 		//    } catch (Throwable e) {
 		//      // ignore
 		//    }

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/SelectionEditPolicyInstaller.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/gef/policy/layout/generic/SelectionEditPolicyInstaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.core.gef.policy.layout.generic;
 
 import org.eclipse.wb.gef.graphical.policies.SelectionEditPolicy;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.state.GlobalState;
 import org.eclipse.wb.internal.core.utils.state.IParametersProvider;
 
@@ -120,13 +121,13 @@ public final class SelectionEditPolicyInstaller {
 		String containerName;
 		{
 			containerName = StringUtils.substringAfterLast(containerClassName, ".model.");
-			containerName = StringUtils.removeEnd(containerName, "Info");
+			containerName = StringUtilities.removeEnd(containerName, "Info");
 		}
 		// containerName + childName
 		{
 			String childClassName = child.getClass().getName();
 			String childName = StringUtils.substringAfterLast(childClassName, ".");
-			childName = StringUtils.removeEnd(childName, "Info");
+			childName = StringUtilities.removeEnd(childName, "Info");
 			//
 			Class<?> clazz = loadClass2(basePackageName, containerName + childName);
 			if (clazz != null) {

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/model/property/category/PropertyCategory.java
@@ -112,7 +112,7 @@ public final class PropertyCategory {
 		if (StringUtils.startsWith(text, "system(")) {
 			String systemText = text;
 			systemText = StringUtilities.removeStart(systemText, "system(");
-			systemText = StringUtils.removeEnd(systemText, ")");
+			systemText = StringUtilities.removeEnd(systemText, ")");
 			try {
 				int priority = Integer.parseInt(systemText);
 				return system(priority);

--- a/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/StringUtilities.java
+++ b/org.eclipse.wb.core/src/org/eclipse/wb/internal/core/utils/StringUtilities.java
@@ -459,4 +459,23 @@ public class StringUtilities {
 	public static String removeStart(String str, String remove) {
 		return Strings.CS.removeStart(str, remove);
 	}
+
+	/**
+	 * Removes a substring only if it is at the end of a source string, otherwise
+	 * returns the source string.
+	 *
+	 * <p>
+	 * A {@code null} source string will return {@code null}. An empty ("") source
+	 * string will return the empty string. A {@code null} search string will return
+	 * the source string.
+	 * </p>
+	 *
+	 * @param str    the source String to search, may be null.
+	 * @param remove the String to search for and remove, may be null.
+	 * @return the substring with the string removed if found, {@code null} if null
+	 *         String input.
+	 */
+	public static String removeEnd(final String str, final String remove) {
+		return Strings.CS.removeEnd(str, remove);
+	}
 }

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanBindableInfo.java
@@ -122,7 +122,7 @@ public class BeanBindableInfo extends BindableInfo {
 			}
 		} else {
 			String localReference = StringUtilities.removeStart(reference, "\"");
-			localReference = StringUtils.removeEnd(localReference, "\"");
+			localReference = StringUtilities.removeEnd(localReference, "\"");
 			return resolvePropertyReference(reference, StringUtils.split(localReference, "."), 0);
 		}
 		return null;
@@ -142,7 +142,7 @@ public class BeanBindableInfo extends BindableInfo {
 			//
 			for (PropertyBindableInfo property : getProperties()) {
 				String propertyReference = StringUtilities.removeStart(property.getReference(), "\"");
-				propertyReference = StringUtils.removeEnd(propertyReference, "\"");
+				propertyReference = StringUtilities.removeEnd(propertyReference, "\"");
 				int pointIndex = propertyReference.lastIndexOf('.');
 				//
 				if (pointIndex != -1) {

--- a/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
+++ b/org.eclipse.wb.rcp.databinding/src/org/eclipse/wb/internal/rcp/databinding/model/beans/bindables/BeanPropertyDescriptorBindableInfo.java
@@ -18,8 +18,6 @@ import org.eclipse.wb.internal.core.databinding.model.presentation.SimpleObserve
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.rcp.databinding.ui.providers.TypeImageProvider;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.beans.PropertyDescriptor;
 
 /**
@@ -50,7 +48,7 @@ public final class BeanPropertyDescriptorBindableInfo extends BeanPropertyBindab
 
 	private static String createReference(IObserveInfo parent, String reference) throws Exception {
 		if (parent instanceof BeanPropertyDescriptorBindableInfo bindableParent) {
-			return StringUtils.removeEnd(bindableParent.getReference(), "\"") + "." + reference + "\"";
+			return StringUtilities.removeEnd(bindableParent.getReference(), "\"") + "." + reference + "\"";
 		}
 		return "\"" + reference + "\"";
 	}
@@ -60,7 +58,7 @@ public final class BeanPropertyDescriptorBindableInfo extends BeanPropertyBindab
 			Class<?> objectType) throws Exception {
 		if (parent instanceof BeanPropertyDescriptorBindableInfo bindableParent) {
 			String parentReference = StringUtilities.removeStart(bindableParent.getReference(), "\"");
-			parentReference = StringUtils.removeEnd(parentReference, "\"");
+			parentReference = StringUtilities.removeEnd(parentReference, "\"");
 			//
 			final String bindingReference = parentReference + "." + reference;
 			return new SimpleObservePresentation(reference,

--- a/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/SashFormInfo.java
+++ b/org.eclipse.wb.rcp/src/org/eclipse/wb/internal/rcp/model/widgets/SashFormInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -22,6 +22,7 @@ import org.eclipse.wb.internal.core.model.JavaInfoUtils;
 import org.eclipse.wb.internal.core.model.creation.CreationSupport;
 import org.eclipse.wb.internal.core.model.description.ComponentDescription;
 import org.eclipse.wb.internal.core.model.property.converter.IntegerConverter;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.DomGenerics;
 import org.eclipse.wb.internal.core.utils.state.EditorState;
@@ -195,7 +196,7 @@ public final class SashFormInfo extends CompositeInfo implements ISashFormInfo<C
 			String elementsSource;
 			{
 				elementsSource = StringUtils.repeat("1, ", getChildrenControls().size());
-				elementsSource = StringUtils.removeEnd(elementsSource, ", ");
+				elementsSource = StringUtilities.removeEnd(elementsSource, ", ");
 			}
 			// add invocation
 			String arraySource = "new int[] {" + elementsSource + "}";

--- a/org.eclipse.wb.swing/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.wb.swing;singleton:=true
-Bundle-Version: 1.12.100.qualifier
+Bundle-Version: 1.13.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.wb.internal.swing.Activator
 Bundle-Vendor: %providerName
@@ -106,7 +106,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.core.databinding.observable;bundle-version="[1.13.300,2.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.20.200,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.24.0,2.0.0)";visibility:=reexport,
+ org.eclipse.wb.core;bundle-version="[1.25.0,2.0.0)";visibility:=reexport,
  org.eclipse.wb.core.ui;bundle-version="[1.10.800,2.0.0)";visibility:=reexport,
  org.eclipse.wb.core.java;bundle-version="[1.15.0,2.0.0)";visibility:=reexport,
  org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/laf/LafUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 package org.eclipse.wb.internal.swing.laf;
 
 import org.eclipse.wb.internal.core.DesignerPlugin;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.jdt.core.CodeUtils;
 import org.eclipse.wb.internal.swing.laf.model.LafInfo;
 import org.eclipse.wb.internal.swing.laf.model.UserDefinedLafInfo;
@@ -91,7 +92,7 @@ public final class LafUtils {
 				// use the class name as name of LAF
 				String shortClassName = CodeUtils.getShortClass(className);
 				// strip trailing "LookAndFeel"
-				String lafName = StringUtils.removeEnd(shortClassName, "LookAndFeel");
+				String lafName = StringUtilities.removeEnd(shortClassName, "LookAndFeel");
 				lafList.add(new UserDefinedLafInfo(StringUtils.isEmpty(lafName) ? shortClassName : lafName,
 						className,
 						jarFileName));

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutJavaInfoParticipator.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/layout/LayoutJavaInfoParticipator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,10 +17,9 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddAfter;
 import org.eclipse.wb.internal.core.model.util.surround.SurroundSupport;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * {@link IJavaInfoInitializationParticipator} that performs name-based binding of
@@ -121,7 +120,7 @@ public final class LayoutJavaInfoParticipator implements IJavaInfoInitialization
 			final String layoutName;
 			{
 				String layoutClassName = layoutClass.getName();
-				layoutName = StringUtils.removeEnd(layoutClassName, "Info");
+				layoutName = StringUtilities.removeEnd(layoutClassName, "Info");
 			}
 			// bind safely
 			final Class<?> finalLayoutClass = layoutClass;

--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/font/DerivedFontInfo.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/model/property/editor/font/DerivedFontInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Google, Inc.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,8 +13,7 @@
 package org.eclipse.wb.internal.swing.model.property.editor.font;
 
 import org.eclipse.wb.internal.core.model.property.converter.StringConverter;
-
-import org.apache.commons.lang3.StringUtils;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 
 import java.awt.Font;
 import java.text.MessageFormat;
@@ -226,7 +225,7 @@ public final class DerivedFontInfo extends FontInfo {
 		}
 		// new family
 		if (m_newFamily != null) {
-			sizeSource = StringUtils.removeEnd(sizeSource, "f");
+			sizeSource = StringUtilities.removeEnd(sizeSource, "f");
 			return MessageFormat.format(
 					"new java.awt.Font({0}, {1}, {2})",
 					StringConverter.INSTANCE.toJavaSource(null, m_newFamily),

--- a/org.eclipse.wb.swt/META-INF/MANIFEST.MF
+++ b/org.eclipse.wb.swt/META-INF/MANIFEST.MF
@@ -60,7 +60,7 @@ Export-Package: org.eclipse.wb.internal.swt;x-friends:="org.eclipse.wb.os.linux,
  org.eclipse.wb.internal.swt.utils
 Require-Bundle: org.eclipse.ui;bundle-version="[3.206.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.31.100,4.0.0)",
- org.eclipse.wb.core;bundle-version="[1.24.0,2.0.0)",
+ org.eclipse.wb.core;bundle-version="[1.25.0,2.0.0)",
  org.eclipse.wb.core.java;bundle-version="[1.15.0,2.0.0)",
  org.eclipse.pde.core;bundle-version="[3.18.100,4.0.0)",
  org.eclipse.draw2d;bundle-version="[3.20.0,4.0.0)",

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/DescriptionProcessor.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/DescriptionProcessor.java
@@ -21,6 +21,7 @@ import org.eclipse.wb.internal.core.model.description.ParameterDescription;
 import org.eclipse.wb.internal.core.model.description.helpers.ComponentDescriptionHelper;
 import org.eclipse.wb.internal.core.model.property.editor.DisplayExpressionPropertyEditor;
 import org.eclipse.wb.internal.core.model.property.editor.style.StylePropertyEditor;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.ast.AstEditor;
 import org.eclipse.wb.internal.core.utils.ast.AstParser;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
@@ -30,8 +31,6 @@ import org.eclipse.wb.internal.core.utils.ui.ImageUtils;
 
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Layout;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.beans.BeanInfo;
 import java.lang.reflect.Constructor;
@@ -237,7 +236,7 @@ public final class DescriptionProcessor implements IDescriptionProcessor {
 				}
 				arguments += ", ";
 			}
-			arguments = StringUtils.removeEnd(arguments, ", ");
+			arguments = StringUtilities.removeEnd(arguments, ", ");
 			return arguments;
 		}
 

--- a/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutJavaInfoParticipator.java
+++ b/org.eclipse.wb.swt/src/org/eclipse/wb/internal/swt/model/layout/LayoutJavaInfoParticipator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Google, Inc. and others.
+ * Copyright (c) 2011, 2026 Google, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -17,10 +17,9 @@ import org.eclipse.wb.core.model.JavaInfo;
 import org.eclipse.wb.core.model.ObjectInfo;
 import org.eclipse.wb.core.model.broadcast.ObjectInfoChildAddAfter;
 import org.eclipse.wb.internal.core.model.util.surround.SurroundSupport;
+import org.eclipse.wb.internal.core.utils.StringUtilities;
 import org.eclipse.wb.internal.core.utils.execution.ExecutionUtils;
 import org.eclipse.wb.internal.core.utils.reflect.ReflectionUtils;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * {@link IJavaInfoInitializationParticipator} that performs name-based binding of
@@ -133,7 +132,7 @@ public class LayoutJavaInfoParticipator implements IJavaInfoInitializationPartic
 		final String layoutName;
 		{
 			String layoutClassName = layoutClass.getName();
-			layoutName = StringUtils.removeEnd(layoutClassName, "Info");
+			layoutName = StringUtilities.removeEnd(layoutClassName, "Info");
 		}
 		// try to bind
 		ClassLoader classLoader = ReflectionUtils.getClassLoader(layoutClass);

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/AbstractJavaInfoRelatedTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/core/model/parser/AbstractJavaInfoRelatedTest.java
@@ -224,7 +224,7 @@ public abstract class AbstractJavaInfoRelatedTest extends AbstractJavaTest {
 			}
 		});
 		String result = buffer.toString();
-		result = StringUtils.removeEnd(result, ",\n");
+		result = StringUtilities.removeEnd(result, ",\n");
 		System.out.println(result);
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/DesignerTestCase.java
@@ -427,7 +427,7 @@ public abstract class DesignerTestCase extends Assertions {
 		}
 		// end
 		String result = buffer.toString();
-		result = StringUtils.removeEnd(result, ",\n");
+		result = StringUtilities.removeEnd(result, ",\n");
 		return result;
 	}
 

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/designer/tests/Replacer.java
@@ -15,8 +15,6 @@ package org.eclipse.wb.tests.designer.tests;
 import org.eclipse.wb.internal.core.utils.IOUtils2;
 import org.eclipse.wb.internal.core.utils.StringUtilities;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -101,7 +99,7 @@ public class Replacer {
 				}
 				// begin/end
 				invocation = StringUtilities.removeStart(invocation, begin);
-				invocation = StringUtils.removeEnd(invocation, end);
+				invocation = StringUtilities.removeEnd(invocation, end);
 				//invocation = "createTypeDeclaration_Test0(" + invocation + "\")";
 				invocation = "createTypeDeclaration_Test0(" + invocation;
 				System.out.println(invocation);
@@ -159,7 +157,7 @@ public class Replacer {
   			}
   			// begin/end
   			invocation = StringUtilities.removeStart(invocation, begin);
-  			invocation = StringUtils.removeEnd(invocation, end);
+  			invocation = StringUtilities.removeEnd(invocation, end);
   			invocation = "assertEditor(\"" + invocation + '"';
   			// replace " with '
   			invocation = StringUtils.replace(invocation, "\\\"", "'");
@@ -196,7 +194,7 @@ public class Replacer {
   			String invocation = s.substring(invocationBegin, invocationEnd);
   			// begin/end
   			invocation = StringUtilities.removeStart(invocation, begin);
-  			invocation = StringUtils.removeEnd(invocation, "}");
+  			invocation = StringUtilities.removeEnd(invocation, "}");
   			invocation = "parseComposite("// filler filler filler", " + invocation;
   			// replace " with '
   			invocation = StringUtils.replace(invocation, "\\\"", "'");

--- a/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/StringUtilitiesTest.java
+++ b/org.eclipse.wb.tests/src/org/eclipse/wb/tests/utils/StringUtilitiesTest.java
@@ -298,6 +298,17 @@ public class StringUtilitiesTest extends DesignerTestCase {
 	}
 
 	@Test
+	public void test_removeEnd() {
+		assertEquals(null, StringUtilities.removeEnd(null, "*"));
+		assertEquals("", StringUtilities.removeEnd("", "*"));
+		assertEquals("*", StringUtilities.removeEnd("*", null));
+		assertEquals("www.domain.com", StringUtilities.removeEnd("www.domain.com", ".com."));
+		assertEquals("www.domain", StringUtilities.removeEnd("www.domain.com", ".com"));
+		assertEquals("www.domain.com", StringUtilities.removeEnd("www.domain.com", "domain"));
+		assertEquals("abc", StringUtilities.removeEnd("abc", ""));
+	}
+
+	@Test
 	public void test_removeStart() {
 		assertEquals(null, StringUtilities.removeStart(null, "*"));
 		assertEquals("", StringUtilities.removeStart("", "*"));


### PR DESCRIPTION
This encapsulates the call to StringUtils, to avoid further issues in case they try to do something silly, like deprecating methods that are used in almost every project.