### PR TITLE
Try to stabilize relative location calculation of Swing components #1524

### DIFF
--- a/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
+++ b/org.eclipse.wb.swing/src/org/eclipse/wb/internal/swing/utils/SwingUtils.java
@@ -281,8 +281,29 @@ public final class SwingUtils {
 	 */
 	public static Point getRelativeLocation(final Component parentComponent, final Component childComponent)
 			throws Exception {
-		return runObjectLaterAndWait(() -> SwingUtilities.convertPoint(childComponent.getParent(),
-				childComponent.getLocation(), parentComponent));
+		if (EnvironmentUtils.IS_LINUX) {
+			return internalGetRelativeLocationLinux(parentComponent, childComponent);
+		}
+		return internalGetRelativeLocation(parentComponent, childComponent);
+	}
+
+	private static Point internalGetRelativeLocationLinux(final Component parentComponent, final Component childComponent) throws Exception {
+		long end = System.currentTimeMillis() + 1000;
+		Point p;
+		do {
+			p = internalGetRelativeLocation(parentComponent, childComponent);
+			// The Swing component is moved asynchronously by the window manager. Wait until we get a consistent result
+			Point p1 = internalGetRelativeLocation(parentComponent, childComponent);
+			if (p.equals(p1)) {
+				break;
+			}
+		} while (System.currentTimeMillis() < end);
+		return p;
+
+	}
+
+	private static Point internalGetRelativeLocation(final Component parentComponent, final Component childComponent) throws Exception {
+		return runObjectLaterAndWait(() -> SwingUtilities.convertPoint(childComponent.getParent(), childComponent.getLocation(), parentComponent));
 	}
 
 	/**


### PR DESCRIPTION
The way a Swing component is moved on Linux is via a request to the window manager, which is then processed asynchronously. Because of this, it might happen that the relative location of two widgets is calculated while one is being moved, leading to wildly inaccurate results.

To reduce the likelihood of this happening, we wait until the offset remains the same two times in a row, which makes it very likely that the move as completed.

Closes https://github.com/eclipse-windowbuilder/windowbuilder/issues/1524